### PR TITLE
Added Font Fixes

### DIFF
--- a/gamesinfo/cyberpunk.sh
+++ b/gamesinfo/cyberpunk.sh
@@ -2,6 +2,6 @@ game_steam_subdirectory="Cyberpunk 2077"
 game_nexusid="cyberpunk2077"
 game_appid=1091500
 game_executable="REDprelauncher.exe"
-game_protontricks=("xaudio2_7=native" "d3dcompiler_47" "vcrun2022")
+game_protontricks=("xaudio2_7=native" "d3dcompiler_47" "vcrun2022" "arial" "fontsmooth=rgb")
 game_scriptextender_url=""
 game_scriptextender_files=""

--- a/gamesinfo/enderal.sh
+++ b/gamesinfo/enderal.sh
@@ -2,6 +2,6 @@ game_steam_subdirectory="Enderal"
 game_nexusid="enderal"
 game_appid=933480
 game_executable="Enderal Launcher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://skse.silverlock.org/beta/skse_1_07_03.7z"
 game_scriptextender_files=""

--- a/gamesinfo/enderal_se.sh
+++ b/gamesinfo/enderal_se.sh
@@ -2,6 +2,6 @@ game_steam_subdirectory="Enderal Special Edition"
 game_nexusid="enderalspecialedition"
 game_appid=976620
 game_executable="Enderal Launcher.exe"
-game_protontricks=("xaudio2_7=native")
+game_protontricks=("xaudio2_7=native" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_01_05.7z"
 game_scriptextender_files=""

--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -2,7 +2,7 @@ game_appid=22300
 game_executable="FalloutLauncherSteam.exe"
 game_nexusid="fallout3"
 game_steam_subdirectory="Fallout 3"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://www.fose.silverlock.org/download/fose_v1_2_beta2.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/fallout3_goty.sh
+++ b/gamesinfo/fallout3_goty.sh
@@ -2,7 +2,7 @@ game_appid=22370
 game_executable="FalloutLauncherSteam.exe"
 game_nexusid="fallout3"
 game_steam_subdirectory="Fallout 3 goty"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://www.fose.silverlock.org/download/fose_v1_2_beta2.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/fallout4.sh
+++ b/gamesinfo/fallout4.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Fallout 4"
 game_nexusid="fallout4"
 game_appid=377160
 game_executable="Fallout4Launcher.exe"
-game_protontricks=("xaudio2_7=native" "grabfullscreen=y")
+game_protontricks=("xaudio2_7=native" "grabfullscreen=y" "arial" "fontsmooth=rgb")
 game_scriptextender_url=""
 game_scriptextender_files=""
 

--- a/gamesinfo/morrowind.sh
+++ b/gamesinfo/morrowind.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Morrowind"
 game_nexusid="morrowind"
 game_appid=22320
 game_executable="Morrowind Launcher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://github.com/MWSE/MWSE/releases/download/build-automatic/mwse.zip"
 game_scriptextender_files="*"
 

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Fallout New Vegas"
 game_nexusid="newvegas"
 game_appid=22380
 game_executable="FalloutNVLauncher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.5/nvse_6_3_5b.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/newvegas_ru.sh
+++ b/gamesinfo/newvegas_ru.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Fallout New Vegas enplczru"
 game_nexusid="newvegas"
 game_appid=22490
 game_executable="FalloutNVLauncher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.5/nvse_6_3_5b.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/oblivion.sh
+++ b/gamesinfo/oblivion.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Oblivion"
 game_nexusid="oblivion"
 game_appid=22330
 game_executable="OblivionLauncher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://github.com/llde/xOBSE/releases/download/22.5/xOBSE22.5.zip"
 game_scriptextender_files="*"
 

--- a/gamesinfo/skyrim.sh
+++ b/gamesinfo/skyrim.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Skyrim"
 game_nexusid="skyrim"
 game_appid=72850
 game_executable="SkyrimLauncher.exe"
-game_protontricks=("d3dcompiler_43" "d3dx9")
+game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://skse.silverlock.org/beta/skse_1_07_03.7z"
 game_scriptextender_files=( \
 	"skse_1_07_03/Data" \

--- a/gamesinfo/skyrimspecialedition.sh
+++ b/gamesinfo/skyrimspecialedition.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Skyrim Special Edition"
 game_nexusid="skyrimspecialedition"
 game_appid=489830
 game_executable="SkyrimSELauncher.exe"
-game_protontricks=("xaudio2_7=native" "d3dcompiler_47" "vcrun2022")
+game_protontricks=("xaudio2_7=native" "d3dcompiler_47" "vcrun2022" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_02_06.7z"
 game_scriptextender_files=( \
 	"skse64_2_02_06/Data" \

--- a/gamesinfo/skyrimvr.sh
+++ b/gamesinfo/skyrimvr.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="SkyrimVR"
 game_nexusid="skyrimspecialedition"
 game_appid=611670
 game_executable="SkyrimVR.exe"
-game_protontricks=("xaudio2_7=native")
+game_protontricks=("xaudio2_7=native" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://skse.silverlock.org/beta/sksevr_2_00_12.7z"
 game_scriptextender_files=( \
 	"sksevr_2_00_12/Data" \

--- a/gamesinfo/starfield.sh
+++ b/gamesinfo/starfield.sh
@@ -2,7 +2,7 @@ game_steam_subdirectory="Starfield"
 game_nexusid="starfield"
 game_appid=1716740
 game_executable="Starfield.exe"
-game_protontricks=("xaudio2_7=native")
+game_protontricks=("xaudio2_7=native" "arial" "fontsmooth=rgb")
 game_scriptextender_url="https://sfse.silverlock.org/download/sfse_0_2_15.7z"
 game_scriptextender_files=( \
 	"sfse_0_2_15/sfse_1_14_70.dll" \


### PR DESCRIPTION
As the title suggests this merge adds "arial" and "fontsmooth=rgb" protontricks commands to every install insuring MO2 has antialiased arial font to avoid odd text rendering.