### PR TITLE
Added Font Fixes, Honed Down Focus of Beta Branch, Updated Beta Branch MO2 to 2.5.3dev6

### DIFF
--- a/gamesinfo/oblivionremastered.sh
+++ b/gamesinfo/oblivionremastered.sh
@@ -2,6 +2,6 @@ game_steam_subdirectory="Oblivion Remastered"
 game_nexusid="oblivionremastered"
 game_appid=2623190
 game_executable="OblivionRemastered.exe"
-game_protontricks=("")
+game_protontricks=("arial" "fontsmooth=rgb")
 game_scriptextender_url=""
 game_scriptextender_files=""

--- a/step/download_external_resources.sh
+++ b/step/download_external_resources.sh
@@ -5,7 +5,7 @@ extract="$utils/extract.sh"
 
 jdk_url='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u312-b07/OpenJDK8U-jre_x64_windows_hotspot_8u312b07.zip'
 
-mo2_url='https://my.microsoftpersonalcontent.com/personal/371272c49a37cc4a/_layouts/15/download.aspx?UniqueId=2e52a0d5-53da-45a4-a556-4b9f860d65c6&Translate=false&ApiVersion=2.0'
+mo2_url='https://my.microsoftpersonalcontent.com/personal/371272c49a37cc4a/_layouts/15/download.aspx?UniqueId=afa1c151-318d-4f51-8e03-a8756f7d0c9c&Translate=false&ApiVersion=2.0'
 
 winetricks_url='https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks'
 

--- a/step/select_game.sh
+++ b/step/select_game.sh
@@ -15,21 +15,7 @@ selected_game=$( \
 	"$dialog" \
 		radio \
 		450 "$screen_text" \
-		"cyberpunk" "Cyberpunk 2077" \
-		"enderal" "Enderal: Forgotten Stories" \
-		"enderal_se" "Enderal: Forgotten Stories (Special Edition)" \
-		"fallout3" "Fallout 3" \
-		"fallout3_goty" "Fallout 3 - Game of the Year Edition" \
-		"fallout4" "Fallout 4" \
-		"newvegas" "Fallout: New Vegas" \
-		"newvegas_ru" "Fallout: New Vegas RU" \
-		"morrowind" "Morrowind" \
-		"oblivion" "Oblivion" \
-  		"oblivionremastered" "Oblivion Remastered" \
-		"skyrim" "Skyrim" \
-		"skyrimspecialedition" "Skyrim Special Edition" \
-		"skyrimvr" "Skyrim VR" \
-		"starfield" "Starfield"\
+  		"oblivionremastered" "Oblivion Remastered"\
 )
 
 if [ -z "$selected_game" ]; then


### PR DESCRIPTION
As the title suggests this merge request does three things.

1. Adds "arial" and "fontsmooth=rgb" protontricks commands to every install ensuring MO2 has antialiased arial font to avoid odd text rendering.
2. Deletes every game selection save for Oblivion Remastered from the beta branch to really insist the end user to use the main release for other games until 2.5.3 launches in full.
3. Updates the MO2 link to 2.5.3dev6 in the beta branch only. 