### PR TITLE
Removing outdated script extender from Starfield.sh

### DIFF
--- a/gamesinfo/starfield.sh
+++ b/gamesinfo/starfield.sh
@@ -3,9 +3,5 @@ game_nexusid="starfield"
 game_appid=1716740
 game_executable="Starfield.exe"
 game_protontricks=("xaudio2_7=native" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://sfse.silverlock.org/download/sfse_0_2_15.7z"
-game_scriptextender_files=( \
-	"sfse_0_2_15/sfse_1_14_70.dll" \
-	"sfse_0_2_15/sfse_loader.exe" \
-)
-
+game_scriptextender_url=""
+game_scriptextender_files=""


### PR DESCRIPTION
Just removing the outdated script extender files: The game has been updated to version 1.15.216 and a new SFSE version 0.2.17 has been released, but it seems this will only be uploaded directly to Nexus and not on sfse.silverlock.org as a direct link anymore.