### PR TITLE
Updating the script extender on some of the games

### DIFF
--- a/gamesinfo/enderal_se.sh
+++ b/gamesinfo/enderal_se.sh
@@ -3,5 +3,5 @@ game_nexusid="enderalspecialedition"
 game_appid=976620
 game_executable="Enderal Launcher.exe"
 game_protontricks=("xaudio2_7=native" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_01_05.7z"
+game_scriptextender_url="https://skse.silverlock.org/beta/skse64_2_02_06.7z"
 game_scriptextender_files=""

--- a/gamesinfo/fallout3.sh
+++ b/gamesinfo/fallout3.sh
@@ -3,6 +3,6 @@ game_executable="FalloutLauncherSteam.exe"
 game_nexusid="fallout3"
 game_steam_subdirectory="Fallout 3"
 game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://www.fose.silverlock.org/download/fose_v1_2_beta2.7z"
+game_scriptextender_url="https://www.fose.silverlock.org/beta/fose_v1_3_beta2.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/fallout3_goty.sh
+++ b/gamesinfo/fallout3_goty.sh
@@ -3,6 +3,6 @@ game_executable="FalloutLauncherSteam.exe"
 game_nexusid="fallout3"
 game_steam_subdirectory="Fallout 3 goty"
 game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://www.fose.silverlock.org/download/fose_v1_2_beta2.7z"
+game_scriptextender_url="https://www.fose.silverlock.org/beta/fose_v1_3_beta2.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/newvegas.sh
+++ b/gamesinfo/newvegas.sh
@@ -3,6 +3,6 @@ game_nexusid="newvegas"
 game_appid=22380
 game_executable="FalloutNVLauncher.exe"
 game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.5/nvse_6_3_5b.7z"
+game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.10/nvse_6_3_10b.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/newvegas_ru.sh
+++ b/gamesinfo/newvegas_ru.sh
@@ -3,6 +3,6 @@ game_nexusid="newvegas"
 game_appid=22490
 game_executable="FalloutNVLauncher.exe"
 game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.5/nvse_6_3_5b.7z"
+game_scriptextender_url="https://github.com/xNVSE/NVSE/releases/download/6.3.10/nvse_6_3_10b.7z"
 game_scriptextender_files="*"
 

--- a/gamesinfo/oblivion.sh
+++ b/gamesinfo/oblivion.sh
@@ -3,6 +3,6 @@ game_nexusid="oblivion"
 game_appid=22330
 game_executable="OblivionLauncher.exe"
 game_protontricks=("d3dcompiler_43" "d3dx9" "arial" "fontsmooth=rgb")
-game_scriptextender_url="https://github.com/llde/xOBSE/releases/download/22.5/xOBSE22.5.zip"
+game_scriptextender_url="https://github.com/llde/xOBSE/releases/download/22.12.1/xOBSE-22.12.1.zip"
 game_scriptextender_files="*"
 


### PR DESCRIPTION
I realized that some of the script extender links were outdated on Fallout 3, New Vegas, Oblivion and Enderal SE and just updated them to the last versions available.