### PR TITLE
Remove invalid -z evaluator

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ else
 fi
 
 selected_plugins=$(source "$step/select_plugins.sh")
-if [ -n -z "$selected_plugins" ]; then
+if [ -n "$selected_plugins" ]; then
 	log_info "selected plugins '$selected_plugins'"
 fi
 source "$step/load_plugininfo.sh"


### PR DESCRIPTION
Fixes an error when running the installer where `-z` is invalid. The `-n` and `-z` evaluators are mutually exclusive. Without this fix the installer prints a warning:
```
./install.sh: line 105: [: -z: binary operator expected
```