### PR TITLE
Fix Fallout 3 downgrade check

### DIFF
--- a/utils/find-library-for-file.sh
+++ b/utils/find-library-for-file.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-desired_file=$1
-
 if [ -n "$STEAM_LIBRARY" ]; then
 	echo "$STEAM_LIBRARY"
 	exit 0
@@ -11,16 +9,30 @@ function log_info() {
 	echo "INFO:" "$@" >&2
 }
 
+function log_error() {
+	echo "ERROR:" "$@" >&2
+}
+
 script_root=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 
-"$script_root/list-steam-libraries.sh" | \
 while read -r libdir; do
-	full_path="$libdir/steamapps/common/$desired_file"
+	full_path="$libdir/steamapps/common/$game_steam_subdirectory/$game_executable"
+
 	if [ -f "$full_path" ]; then
 		log_info "game found in '$libdir'"
 		echo "$libdir"
 		exit 0
 	else
+		## Fallout 3 Downgrade Check
+		if { [ "$game_appid" -eq 22300 ] || [ "$game_appid" -eq 22370 ]; } &&
+			[ -f "$libdir/steamapps/common/$game_steam_subdirectory/Fallout3Launcher.exe" ]; then
+			log_error "Fallout 3 and Fallout 3 GOTY require the game version to be downgraded. Instructions have been provided in the GitHub Wiki."
+
+			"$dialog" errorbox \
+				"Fallout 3 and Fallout 3 GOTY require the game version to be downgraded.\n\nInstructions have been provided in the GitHub Wiki."
+			exit 2
+		fi
 		log_info "game not found in '$libdir'"
 	fi
-done
+done < <("$script_root/list-steam-libraries.sh")
+exit 1


### PR DESCRIPTION
This is another attempt to fix the unreachable check identified in #844.

Currently, the check is not working as intended for three reasons:

1. The code block is still unreachable. If Fallout3LauncherSteam.exe is not found, then the `if [ ! -d "$steam_library" ]` block will be entered and we will hit `exit 1` before we have a chance to search for Fallout3Launcher.exe. We could have find-library-for-file.sh return a directory *regardless* of success, but then we would have to repeat the search for the game executable to disambiguate between the game being installed or not; furthermore, we would only be searching in *one*, not *all* of the user's libraries.
2. The check is looking in the wrong folder anyway: to use the former conventions, it should be looking in `$steam_library/steamapps/common/$game_steam_subdirectory/Fallout3Launcher.exe`.
3. If one follows the [workaround instructions](https://github.com/Furglitch/modorganizer2-linux-installer/wiki/Downgrading-Fallout-3) verbatim (copying all files from the download depot to the game folder), the user will end up with a game folder that contains **both** Fallout3Launcher.exe and Fallout3LauncherSteam.exe. So even if we fix the above problems, we would start *incorrectly* displaying this dialog to users that have correctly followed the instructions.

What we need to do is check that Fallout3Launcher.exe exists, but also Fallout3LauncherSteam.exe does *not* exist. We also should avoid showing the "Could not find Fallout 3" dialog after showing the "You need to downgrade Fallout 3" dialog, as this is incorrect and confusing.

In order to resolve all of this, I've moved the check into the script find-library-for-file.sh. This script has access to all the Steam library folders, making it well situated for the check. We also perform it only if Fallout3LauncherSteam.exe is not found. In order to facilitate this, we switch to using environment variables to provide input for find-library-for-file.sh rather than positional arguments.

Script find-library-for-file.sh now returns different error codes for the following cases:

0: Success
1: Game not installed
2: Fallout 3 is installed, but must be downgraded

This ternary classification allows us to determine in load_game_info.sh whether or not to display the "Could not find" dialog, as opposed to the former binary test of $steam_library being non-empty.