### PR TITLE
Add option to ignore winetricks failures

### DIFF
--- a/step/configure_steam_wineprefix.sh
+++ b/step/configure_steam_wineprefix.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "${game_protontricks[*]}" ]; then
+do_wineprefix_work() {
 	case "$game_launcher" in
 	steam)
 		log_info "applying protontricks ${game_protontricks[@]}"
@@ -23,8 +23,10 @@ if [ -n "${game_protontricks[*]}" ]; then
 		)
 		;;
 	esac | "$dialog" loading "Configuring game prefix\nThis may take a while.\n\nFailure at this step may indicate an issue with Winetricks/Protontricks."
+}
 
-	if [ "$?" != "0" ]; then
+if [ -n "${game_protontricks[*]}" ]; then
+	if ! do_wineprefix_work; then
 		"$dialog" errorbox \
 			"Error while installing winetricks, check the terminal for more details"
 		exit 1

--- a/step/configure_steam_wineprefix.sh
+++ b/step/configure_steam_wineprefix.sh
@@ -39,5 +39,7 @@ if [ "${#game_protontricks[@]}" -gt 0 ]; then
 			expect_exit=1
 			exit 1
 		fi
+
+		log_warn "error occurred while running winetricks, user chose to ignore and continue"
 	fi
 fi

--- a/step/configure_steam_wineprefix.sh
+++ b/step/configure_steam_wineprefix.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+# Add MO2 required winetricks to game_protontricks.
+game_protontricks=("arial" "fontsmooth=rgb" "${game_protontricks[@]}")
+
 do_wineprefix_work() {
 	case "$game_launcher" in
 	steam)
 		log_info "applying protontricks ${game_protontricks[@]}"
-		"$utils/protontricks.sh" apply "$game_steam_id" "arial" "fontsmooth=rgb" "${game_protontricks[@]}"
+		"$utils/protontricks.sh" apply "$game_steam_id" "${game_protontricks[@]}"
 		;;
 	heroic)
 		(
@@ -19,13 +22,13 @@ do_wineprefix_work() {
 
 			fi
 			export executable_winetricks
-			"$utils/winetricks.sh" apply "arial" "fontsmooth=rgb" "${game_protontricks[@]}"
+			"$utils/winetricks.sh" apply "${game_protontricks[@]}"
 		)
 		;;
 	esac | "$dialog" loading "Configuring game prefix\nThis may take a while.\n\nFailure at this step may indicate an issue with Winetricks/Protontricks."
 }
 
-if [ -n "${game_protontricks[*]}" ]; then
+if [ "${#game_protontricks[@]}" -gt 0 ]; then
 	if ! do_wineprefix_work; then
 		confirm_ignore_protontricks=$(
 			"$dialog" dangerquestion \

--- a/step/configure_steam_wineprefix.sh
+++ b/step/configure_steam_wineprefix.sh
@@ -27,8 +27,14 @@ do_wineprefix_work() {
 
 if [ -n "${game_protontricks[*]}" ]; then
 	if ! do_wineprefix_work; then
-		"$dialog" errorbox \
-			"Error while installing winetricks, check the terminal for more details"
-		exit 1
+		confirm_ignore_protontricks=$(
+			"$dialog" dangerquestion \
+				"Error while installing winetricks, check the terminal for more details. Would you like to ignore this error and continue?"
+		)
+
+		if [ "$confirm_ignore_protontricks" != "0" ]; then
+			expect_exit=1
+			exit 1
+		fi
 	fi
 fi


### PR DESCRIPTION
The main change of this patch is to replace the errorbox displayed after we try and fail to install winetricks into the game's WINEPREFIX with a dangerquestion that allows the user to override the error and proceed with the remaining installation steps.

I believe this is justifiable because the user may wish to try MO2 and see if it works despite the error, or troubleshoot by running protontricks/winetricks on their own in a terminal to install verbs, possibly after downloading a newer version of that script.

This patch also fixes two adjacent bugs:

- It is impossible to display the "Error while installing winetricks" dialog as intended in the current version. Because of `set -e`, we exit the script before that line can be reached and display the generic "Operation failed" dialog instead; see 356a1eaff48232f21374aec7eccc0772a3115311 for the fix and more details.
- We skip running the tricks **arial** and **fontsmooth=rgb** unless the game has *other* tricks to run besides those two. If I understand things correctly, those are required by MO2 itself and therefore should always be applied. Commit 4cb978bf6ef6c69f3a7e8b0f85d50ffbea48c62b fixes this.