### PR TITLE
Argument Filtering

### DIFF
--- a/steam-redirector/Makefile
+++ b/steam-redirector/Makefile
@@ -9,7 +9,7 @@ all: main.exe main
 
 # this build is mostly for debugging purposes
 main: main.c unix_utils.c
-	$(GNU_C) -o main unix_utils.c main.c
+	$(GNU_C) -g -o main unix_utils.c main.c
 
 main.exe: $(WIN_SRC)
 	$(WIN_C) $(WIN_FLAGS) -mwindows -o main.exe $^

--- a/steam-redirector/unix_utils.c
+++ b/steam-redirector/unix_utils.c
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include <stdio.h>
+#include <string.h>
 
 #include "unix_utils.h"
 
@@ -15,3 +15,10 @@ void check_can_execute(const char_t* path) {
 	access(path, X_OK);
 }
 
+char_t* str_contains(const char_t* string, const char_t* substring) {
+	return strstr(string, substring);
+}
+
+int str_compare(const char_t* lhs, const char_t* rhs) {
+	return strcmp(lhs, rhs);
+}

--- a/steam-redirector/unix_utils.h
+++ b/steam-redirector/unix_utils.h
@@ -12,3 +12,6 @@ void execute(const char_t* path, const char_t* arg);
 
 void check_can_execute(const char_t* path);
 
+char_t* str_contains(const char_t* string, const char_t* substring);
+
+int str_compare(const char_t* lhs, const char_t* rhs);

--- a/steam-redirector/win32_utils.c
+++ b/steam-redirector/win32_utils.c
@@ -40,3 +40,10 @@ char_t* convert_utf8_to_wchar(const char* str) {
 	return converted_str;
 }
 
+char_t* str_contains(const char_t* string, const char_t* substring) {
+	return wcsstr(string, substring);
+}
+
+int str_compare(const char_t* lhs, const char_t* rhs) {
+	return wcscmp(lhs, rhs);
+}

--- a/steam-redirector/win32_utils.h
+++ b/steam-redirector/win32_utils.h
@@ -18,3 +18,6 @@ char_t read_character(FILE* file);
 
 char_t* convert_utf8_to_wchar(const char* str);
 
+char_t* str_contains(const char_t* string, const char_t* substring);
+
+int str_compare(const char_t* lhs, const char_t* rhs);


### PR DESCRIPTION
re: #835. I am bad at GitHub apparently.

Add argument filtering to Steam redirector.

Known args like nxm/moshortcut protocol URIs (and the --pick flag) are passed to MO2, while other arguments are logged for addition to the game executable's args in MO2 if necessary.

Should help with https://github.com/Furglitch/modorganizer2-linux-installer/issues/799, but still needs support for downloading plugins from Nexus Mods to be truly seamless. May also aid https://github.com/Furglitch/modorganizer2-linux-installer/issues/789 in general.

May or may not be irrelevant due to #873, but figured I'd undo my screw-up so the code is available.