### PR TITLE
Update protontricks to include d3dcompiler_47

### DIFF
--- a/gamesinfo/skyrimspecialedition.sh
+++ b/gamesinfo/skyrimspecialedition.sh
@@ -4,7 +4,7 @@ game_gog_id=1711230643
 game_epic_id=""
 game_steam_subdirectory="Skyrim Special Edition"
 game_executable="SkyrimSELauncher.exe"
-game_protontricks=("xaudio2_7=native" "xact" "d3dcompiler_43" "vcrun2022")
+game_protontricks=("xaudio2_7=native" "xact" "d3dcompiler_43" "d3dcompiler_47" "vcrun2022")
 declare -A game_scriptextender_urls=(
 	["steam"]="https://skse.silverlock.org/beta/skse64_2_02_06.7z"
 	["gog"]=""


### PR DESCRIPTION
This is for the popular mod [Community Shaders](https://www.nexusmods.com/skyrimspecialedition/mods/86492), an alternative to ENB (and arguably better option to Linux users).

While ENB ships with `d3dcompiler_46e`, Community Shaders does not ship with it's required `d3dcompiler_47`.

It was a pretty infuriating couple hours only to end being the missing `d3dcompiler_47`
So from my pain, I'm hoping to save other people some headaches.

also see: https://github.com/doodlum/skyrim-community-shaders/wiki/MacOS-and-Linux-Support