### PR TITLE
Fix type hint forward references

### DIFF
--- a/src/mo2-lint/util/state_file.py
+++ b/src/mo2-lint/util/state_file.py
@@ -33,7 +33,7 @@ class NexusAPIData:
 
     @classmethod
     def from_dict(
-        cls, data: dict[str, any] | "NexusAPIData"
+        cls, data: "dict[str, any] | NexusAPIData"
     ) -> Optional["NexusAPIData"]:
         if isinstance(data, cls):
             return data
@@ -105,7 +105,7 @@ class InstanceData:
     plugins: Optional[list[str]] = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "InstanceData") -> "InstanceData":
+    def from_dict(cls, data: "dict[str, any] | InstanceData") -> "InstanceData":
         if isinstance(data, cls):
             return data
         return cls(
@@ -171,7 +171,7 @@ class StateFile:
     instances: list[InstanceData] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "StateFile") -> "StateFile":
+    def from_dict(cls, data: "dict[str, any] | StateFile") -> "StateFile":
         if isinstance(data, cls):
             return data
         return cls(

--- a/src/mo2-lint/util/variables.py
+++ b/src/mo2-lint/util/variables.py
@@ -124,7 +124,7 @@ class DownloadData:
     nexus: Optional[dict[str, int | str]] = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "DownloadData") -> "DownloadData":
+    def from_dict(cls, data: "dict[str, any] | DownloadData") -> "DownloadData":
         if isinstance(data, cls):
             return data
         return cls(
@@ -184,7 +184,7 @@ class FileWhitelist:
     paths: Tuple[str, ...] = field(default_factory=tuple)
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "FileWhitelist") -> "FileWhitelist":
+    def from_dict(cls, data: "dict[str, any] | FileWhitelist") -> "FileWhitelist":
         if isinstance(data, cls):
             return data
         return cls(
@@ -231,7 +231,7 @@ class ScriptExtender:
     file_whitelist: Optional[FileWhitelist] = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "ScriptExtender") -> "ScriptExtender":
+    def from_dict(cls, data: "dict[str, any] | ScriptExtender") -> "ScriptExtender":
         if isinstance(data, cls):
             return data
         return cls(
@@ -297,7 +297,7 @@ class LauncherIDs:
     epic: Optional[str] = None
 
     @classmethod
-    def from_dict(cls, data: dict | "LauncherIDs") -> "LauncherIDs":
+    def from_dict(cls, data: "dict | LauncherIDs") -> "LauncherIDs":
         if isinstance(data, cls):
             return data
         return cls(
@@ -368,7 +368,7 @@ class GameInfo:
     workarounds: Optional[dict] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "GameInfo") -> "GameInfo":
+    def from_dict(cls, data: "dict[str, any] | GameInfo") -> "GameInfo":
         if isinstance(data, cls):
             return data
         return cls(
@@ -532,7 +532,7 @@ class Resource:
     file_whitelist: Optional[FileWhitelist] = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "Resource") -> "Resource":
+    def from_dict(cls, data: "dict[str, any] | Resource") -> "Resource":
         if isinstance(data, cls):
             return data
         return cls(
@@ -586,7 +586,7 @@ class ResourceInfo:
     java: Optional[Resource] = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any] | "ResourceInfo") -> "ResourceInfo":
+    def from_dict(cls, data: "dict[str, any] | ResourceInfo") -> "ResourceInfo":
         if isinstance(data, cls):
             return data
         return cls(


### PR DESCRIPTION
Just a quick fix for the following syntax error:

```ini
Traceback (most recent call last):
  File "__init__.py", line 7, in <module>
    from util import lang, state_file as state, variables as var
  File "/tmp/_MEI5KkPdc/src/util/lang.py", line 6, in <module>
    from util import state_file as state, variables as var
  File "/tmp/_MEI5KkPdc/src/util/state_file.py", line 10, in <module>
    from util import lang, variables as var, state_file as state
  File "/tmp/_MEI5KkPdc/src/util/variables.py", line 84, in <module>
    class DownloadData:
    ...<81 lines>...
                raise SystemExit(1)
  File "/tmp/_MEI5KkPdc/src/util/variables.py", line 127, in DownloadData
    def from_dict(cls, data: dict[str, any] | "DownloadData") -> "DownloadData":
                             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'str'
[PYI-376841:ERROR] Failed to execute script '__init__' due to unhandled exception!
```