### PR TITLE
Fix uninstall on games where the game slug and nexus slug don't match

### DIFF
--- a/src/mo2-lint/command/uninstall.py
+++ b/src/mo2-lint/command/uninstall.py
@@ -17,31 +17,26 @@ def uninstall(game=None, directory=None):
         The instance directory to match.
     """
 
-    instance_list = []
-
     matched = match_instances(game, directory)
-    length = len(matched)
     choice = []
 
-    if not length or length == 0:
+    if not len(matched):
         logger.error(f"No MO2 instance found for game={game}, directory={directory}")
         return
 
-    if length == 1:
+    if len(matched) == 1:
         logger.debug(
             f"Found 1 matching Mod Organizer 2 instance for game={game}, directory={directory}"
         )
         choice = matched
     else:
         logger.debug(
-            f"Found {length} matching Mod Organizer 2 instances for game={game}, directory={directory}"
+            f"Found {len(matched)} matching Mod Organizer 2 instances for game={game}, directory={directory}"
         )
-        for instance in matched:
-            instance_list.append(instance)
-        instance = lang.prompt_uninstall_choice(instance_list)
+        instance = lang.prompt_uninstall_choice(matched)
         logger.debug(f"User selected instance for uninstallation: {instance}")
         if isinstance(instance, int):
-            if not (0 < instance < (len(matched) + 1)):
+            if not (0 < instance < 1 + len(matched)):
                 logger.warning(f"Invalid instance number selected: {instance}")
                 raise SystemExit(1)
             choice.append(matched[instance - 1])

--- a/src/mo2-lint/util/state_file.py
+++ b/src/mo2-lint/util/state_file.py
@@ -406,9 +406,9 @@ def match_instances(
     Parameters
     ----------
     game : str, optional
-        Nexus Mods slug identifier for the game to match.
+        Return only instances matching this game identifier.
     directory : Path, optional
-        Directory path to match instances against.
+        Return only instances installed at/under this path.
     exact : bool, optional
         If True, requires an exact match for the directory. If False, matches any instance whose directory starts with the given directory.
 
@@ -429,7 +429,7 @@ def match_instances(
         logger.debug("No game or directory criteria provided. Returning all instances.")
 
     for instance in state_file.instances:
-        if game and instance.nexus_slug != game:
+        if game and instance.game != game:
             logger.trace(
                 f"Instance index {instance.index} does not match game slug '{game}'. Skipping."
             )

--- a/src/mo2-lint/util/state_file.py
+++ b/src/mo2-lint/util/state_file.py
@@ -435,32 +435,23 @@ def match_instances(
             )
             continue
 
-        startswith = (
-            str(instance.instance_path).startswith(str(directory))
-            if directory
-            else False
-        )
-        if directory and not startswith:
-            logger.trace(
-                f"Instance index {instance.index} does not match directory '{directory}'. Skipping."
-            )
-            continue
+        if directory:
+            if exact:
+                if instance.instance_path.resolve() != directory.resolve():
+                    logger.trace(
+                        f"Instance index {instance.index} does not match directory '{directory}' exactly. Skipping."
+                    )
+                    continue
+            else:
+                # instance_path.resolve() probably isn't necessary
+                if not instance.instance_path.resolve().is_relative_to(directory.resolve()):
+                    logger.trace(
+                        f"Instance index {instance.index} does not match directory '{directory}'. Skipping."
+                        )
+                    continue
 
-        if exact and directory and (instance.instance_path == directory):
-            logger.trace(
-                f"Instance index {instance.index} matches directory '{directory}' exactly. Adding to matched list."
-            )
-            matched.append(instance)
-            continue
-        elif (game == instance.nexus_slug) or (not exact and directory and startswith):
-            logger.trace(
-                f"Instance index {instance.index} matches criteria (game: '{game}', directory: '{directory}'). Adding to matched list."
-            )
-            matched.append(instance)
-            continue
-        elif not exact and not (game or directory):
-            logger.trace(f"Adding instance index {instance.index} to matched list.")
-            matched.append(instance)
+        logger.trace(f"Adding instance index {instance.index} to matched list.")
+        matched.append(instance)
 
     return matched
 


### PR DESCRIPTION
Notes:

In uninstall.py, I got rid of the extra stored len(matched) because len(matched) is already just a lookup, and matched isn't modified.

In state_file.py, match_instances was checking game id against nexus slug, preventing interacting with instances where the two don't match (except fallout3_goty cause it's the same nexus slug as fallout3). It also had an if/elif logic issue where execution was falling out of the last elif block without adding matched instances to the accumulator.