### PR TITLE
fix: winetricks path returned as string, not path

### DIFF
--- a/src/mo2-lint/util/wine/winetricks.py
+++ b/src/mo2-lint/util/wine/winetricks.py
@@ -9,11 +9,13 @@ import re
 import shutil
 import subprocess
 
-found_exec = shutil.which("winetricks") or "~/.cache/mo2-lint/downloads/winetricks"
+found_exec = Path(
+    shutil.which("winetricks") or "~/.cache/mo2-lint/downloads/winetricks"
+)
 
 
 def run(
-    exec: Optional[Path | str] = found_exec,
+    exec: Optional[Path] = found_exec,
     prefix: Path = None,
     command: List[str] = None,
 ) -> List[str]:
@@ -87,7 +89,7 @@ def run(
 
 
 def apply(
-    exec: Optional[Path | str] = found_exec,
+    exec: Optional[Path] = found_exec,
     prefix: Path = None,
     tricks: List[str] = None,
 ):


### PR DESCRIPTION
Resolves #963