### PR TITLE
fix(nxm-handler): forward NXM downloads to running MO2 without bwrap

### DIFF
--- a/src/nxm-handler/__init__.py
+++ b/src/nxm-handler/__init__.py
@@ -203,7 +203,12 @@ def send_url(instance_dir: Path, url: str, env_info: dict) -> None:
 
     if launcher == "steam":
         cmd = f"wine '{handler}' '{url}'"
-        protontricks.run(["-c", cmd, str(steam_id)])
+        # Run without bwrap containerization. protontricks' pressure-vessel
+        # (bwrap) container isolates this process from the already-running MO2,
+        # which breaks the single-instance IPC that nxmhandler.exe relies on to
+        # forward the download. With bwrap the link is silently dropped; with
+        # --no-bwrap the forward reaches the running instance and queues it.
+        protontricks.run(["--no-bwrap", "-c", cmd, str(steam_id)])
     elif launcher in ["heroic", "gog", "epic"]:
         if release == "stable":
             cmd = [f"{wine}", f"{handler}", f"{url}"]

--- a/src/nxm-handler/__init__.py
+++ b/src/nxm-handler/__init__.py
@@ -203,11 +203,6 @@ def send_url(instance_dir: Path, url: str, env_info: dict) -> None:
 
     if launcher == "steam":
         cmd = f"wine '{handler}' '{url}'"
-        # Run without bwrap containerization. protontricks' pressure-vessel
-        # (bwrap) container isolates this process from the already-running MO2,
-        # which breaks the single-instance IPC that nxmhandler.exe relies on to
-        # forward the download. With bwrap the link is silently dropped; with
-        # --no-bwrap the forward reaches the running instance and queues it.
         protontricks.run(["--no-bwrap", "-c", cmd, str(steam_id)])
     elif launcher in ["heroic", "gog", "epic"]:
         if release == "stable":


### PR DESCRIPTION
## Problem

On Steam games, clicking **Mod Manager Download** on Nexus **silently fails when MO2 is already running** — the download never appears in MO2's download queue and no error is shown (the handler exits 0). Closes #998 and #996.

## Root cause

When MO2 is already running, the Steam branch of `send_url` forwards the link by invoking `nxmhandler.exe` through `protontricks -c`. protontricks runs that command inside a **pressure-vessel (bwrap) container**. That container isolates the forwarding process from the already-running MO2, breaking the single-instance IPC `nxmhandler.exe` uses to hand the link off to the running instance. The link is dropped.

The `err:exec:SHELL_ExecuteW cannot set directory L"Z:\home\...\"Z:\home\..."` line with the doubled home path that shows up in these logs is **a red herring**. Wine logs that error but continues to launch the process anyway, and the exact same line is present on *successful* forwards — so it is not the cause of the failure. (It does originate from a real but harmless upstream quirk in `modorganizer-nxmhandler`, where the quoted executable string is passed to `QFileInfo(...).absolutePath()` for the working directory; not addressed here.)

## Fix

Pass `--no-bwrap` to the protontricks invocation in the Steam path so the forwarding process shares the prefix with the running instance and the link is queued. The Heroic/GOG/Epic paths already call `wine` directly with `WINEPREFIX` and never used bwrap, which is why they were unaffected.

```diff
-        protontricks.run(["-c", cmd, str(steam_id)])
+        protontricks.run(["--no-bwrap", "-c", cmd, str(steam_id)])
```

## Testing

Reproduced on Steam / Starfield / Proton 10.0 with MO2 running, holding `nxmhandler.exe` and the link constant and varying **only** the execution environment:

| Invocation | Download queued? |
|---|---|
| `protontricks -c …` (current behavior, with bwrap) | ❌ no |
| `protontricks --no-bwrap -c …` (this fix) | ✅ yes |
| direct Proton `wine …` (no protontricks) | ✅ yes |

The `--no-bwrap` run landed the download in MO2's `downloads/` folder; the default-bwrap run did not. The harmless `SHELL_ExecuteW` directory error appeared in **all three** runs, including the two that succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)