### PR TITLE
fix(scriptextender): don't crash when Nexus denies a download link

### DIFF
--- a/src/mo2-lint/step/external_resources.py
+++ b/src/mo2-lint/step/external_resources.py
@@ -207,10 +207,8 @@ def download_scriptextender():
     logger.debug(f"Downloaded script extender to {downloaded}")
 
     if not downloaded:
-        logger.warning(
-            "Couldn't auto-download the script extender (the Nexus API only allows "
-            "this for Premium accounts); skipping it. Install it manually from Nexus."
-        )
+        logger.warning("Could not automatically download Script Extender. Manual installation required.")
+        logger.warning("This may be due to an invalid API key or lack of Nexus Premium subscription.")
         return
 
     extract_path = extract_dir / "scriptextender" / downloaded.name

--- a/src/mo2-lint/step/external_resources.py
+++ b/src/mo2-lint/step/external_resources.py
@@ -207,8 +207,12 @@ def download_scriptextender():
     logger.debug(f"Downloaded script extender to {downloaded}")
 
     if not downloaded:
-        logger.warning("Could not automatically download Script Extender. Manual installation required.")
-        logger.warning("This may be due to an invalid API key or lack of Nexus Premium subscription.")
+        logger.warning(
+            "Could not automatically download Script Extender. Manual installation required."
+        )
+        logger.warning(
+            "This may be due to an invalid API key or lack of Nexus Premium subscription."
+        )
         return
 
     extract_path = extract_dir / "scriptextender" / downloaded.name

--- a/src/mo2-lint/step/external_resources.py
+++ b/src/mo2-lint/step/external_resources.py
@@ -151,6 +151,7 @@ def download_scriptextender():
     logger.debug(f"Chosen script extender entry: {choice}")
 
     src = [None, None, None]  # [download source, checksum, file whitelist]
+    downloaded = None
     if choice is None:
         return
     else:
@@ -204,6 +205,13 @@ def download_scriptextender():
                 checksum=src[1],
             )
     logger.debug(f"Downloaded script extender to {downloaded}")
+
+    if not downloaded:
+        logger.warning(
+            "Couldn't auto-download the script extender (the Nexus API only allows "
+            "this for Premium accounts); skipping it. Install it manually from Nexus."
+        )
+        return
 
     extract_path = extract_dir / "scriptextender" / downloaded.name
     extract(downloaded, extract_path)

--- a/src/mo2-lint/util/download.py
+++ b/src/mo2-lint/util/download.py
@@ -115,6 +115,8 @@ def download_nexus(
     )
     try:
         filename = nexus_dl(game, str(mod_id), str(file_id), dest, filename or None)
+        if not filename:
+            return None
         export = dest / filename
         if export.exists() and checksum:
             if compare_checksum(export, checksum):

--- a/src/mo2-lint/util/nexus/download_mod.py
+++ b/src/mo2-lint/util/nexus/download_mod.py
@@ -112,17 +112,16 @@ def nexus_download(
         f"Requesting download link for {game_slug} mod id {mod_id}, file ID: {file_id}"
     )
     response = nexus_request(url)
-    if response.status_code != 200:
-        if response.status_code in (401, 403):
+    code = response.status_code
+    if code != 200:
+        if code in (401, 403):
             logger.error(
-                f"Nexus refused a download link for {game_slug} mod id {mod_id}, "
-                f"file ID: {file_id} (HTTP {response.status_code}). The Nexus API only "
-                "provides direct download links to Premium accounts."
+                f"Nexus API returned unauthorized with HTTP {code} when requesting download for {game_slug} mod id {mod_id}, file ID: {file_id}."
             )
+            logger.warning("This may be due to an invalid API key or lack of Nexus Premium subscription.")
         else:
             logger.error(
-                f"Nexus API returned HTTP {response.status_code} when requesting a "
-                f"download link for {game_slug} mod id {mod_id}, file ID: {file_id}."
+                f"Nexus API returned HTTP {code} when requesting download link for {game_slug} mod id {mod_id}, file ID: {file_id}."
             )
         return ""
     if not filename:
@@ -132,11 +131,8 @@ def nexus_download(
     logger.trace("Parsing download link response Nexus CDN URL")
     links = from_json(response.content)
     if not isinstance(links, list):
-        logger.error(
-            f"Unexpected Nexus download-link response for {game_slug} mod id {mod_id}, "
-            f"file ID: {file_id}: expected a list of CDN entries, got "
-            f"{type(links).__name__}."
-        )
+        logger.error("Unexpected Nexus download uri response. See trace for details.")
+        logger.trace(f"Expected a list of CDN entries, got {type(links).__name__}. Response content: {response.content}")
         return ""
     for item in links:
         if isinstance(item, dict) and item.get("short_name") == "Nexus CDN":

--- a/src/mo2-lint/util/nexus/download_mod.py
+++ b/src/mo2-lint/util/nexus/download_mod.py
@@ -118,7 +118,9 @@ def nexus_download(
             logger.error(
                 f"Nexus API returned unauthorized with HTTP {code} when requesting download for {game_slug} mod id {mod_id}, file ID: {file_id}."
             )
-            logger.warning("This may be due to an invalid API key or lack of Nexus Premium subscription.")
+            logger.warning(
+                "This may be due to an invalid API key or lack of Nexus Premium subscription."
+            )
         else:
             logger.error(
                 f"Nexus API returned HTTP {code} when requesting download link for {game_slug} mod id {mod_id}, file ID: {file_id}."
@@ -132,7 +134,9 @@ def nexus_download(
     links = from_json(response.content)
     if not isinstance(links, list):
         logger.error("Unexpected Nexus download uri response. See trace for details.")
-        logger.trace(f"Expected a list of CDN entries, got {type(links).__name__}. Response content: {response.content}")
+        logger.trace(
+            f"Expected a list of CDN entries, got {type(links).__name__}. Response content: {response.content}"
+        )
         return ""
     for item in links:
         if isinstance(item, dict) and item.get("short_name") == "Nexus CDN":

--- a/src/mo2-lint/util/nexus/download_mod.py
+++ b/src/mo2-lint/util/nexus/download_mod.py
@@ -112,13 +112,34 @@ def nexus_download(
         f"Requesting download link for {game_slug} mod id {mod_id}, file ID: {file_id}"
     )
     response = nexus_request(url)
+    if response.status_code != 200:
+        if response.status_code in (401, 403):
+            logger.error(
+                f"Nexus refused a download link for {game_slug} mod id {mod_id}, "
+                f"file ID: {file_id} (HTTP {response.status_code}). The Nexus API only "
+                "provides direct download links to Premium accounts."
+            )
+        else:
+            logger.error(
+                f"Nexus API returned HTTP {response.status_code} when requesting a "
+                f"download link for {game_slug} mod id {mod_id}, file ID: {file_id}."
+            )
+        return ""
     if not filename:
         filename = get_filename(game_slug, mod_id, file_id)
     path = dest / filename
     download_url = None
     logger.trace("Parsing download link response Nexus CDN URL")
-    for item in from_json(response.content):
-        if item.get("short_name") == "Nexus CDN":
+    links = from_json(response.content)
+    if not isinstance(links, list):
+        logger.error(
+            f"Unexpected Nexus download-link response for {game_slug} mod id {mod_id}, "
+            f"file ID: {file_id}: expected a list of CDN entries, got "
+            f"{type(links).__name__}."
+        )
+        return ""
+    for item in links:
+        if isinstance(item, dict) and item.get("short_name") == "Nexus CDN":
             download_url = item.get("URI", "").replace("\\u0026", "&")
             break
     if not download_url:


### PR DESCRIPTION
## Problem

`mo2-lint install <game> ... --script-extender` aborts with an unhandled exception for **non-Premium Nexus accounts**. Installing without `--script-extender` works fine. Closes #1004.

```
File "src/util/nexus/download_mod.py", line 121, in nexus_download
    if item.get("short_name") == "Nexus CDN":
       └ 'code'
AttributeError: 'str' object has no attribute 'get'
```

## Root cause

The script-extender flow requests a download link from `.../files/<id>/download_link.json`. From the reporter's log:

```
files/55300/download_link.json  → 403
files/55300.json (metadata)     → 200
```

The metadata call (same API key) succeeds, but `download_link.json` returns **403** — that endpoint only returns a link *without* an nxm `key`/`expires` for **Premium** accounts. On 403 the body is a JSON *object* (`{"code":403,"message":...}`), not the expected array of CDN entries. `nexus_download` iterated it, which yields the dict's **keys** (so `item == "code"`, a `str`), and `.get()` raised. The response status was never checked. The exception bubbled up (via `download_nexus` returning `None`, then `None.name` in the caller) and aborted the whole install.

So script-extender auto-download is inherently Premium-only; non-Premium users should get a clear message and a completed install, not a crash.

## Fix (defense in depth)

- **`nexus_download`** — check the response status (explicitly noting the Premium requirement on 401/403) and verify the parsed body is a `list` before iterating; return `""` on failure instead of raising.
- **`download_nexus`** — treat an empty filename as a failed download (`return None`) rather than resolving to the destination directory.
- **`download_scriptextender`** — when the download fails, log a concise warning and skip the script extender so the rest of the install **finishes**, instead of dereferencing `None`.

Result for non-Premium accounts: MO2 installs normally and the log shows a clear, actionable warning instead of a traceback.

## Testing

No unit-test harness exists in the repo, so verified the parsing logic directly against a simulated 403 body:

- Old code on a 403 object → reproduces `AttributeError: 'str' object has no attribute 'get'`.
- New code on a 403 object → returns `''` gracefully.
- New code on a valid 200 list → still returns the CDN URL (with `\u0026` unescaped to `&`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
