### PR TITLE
fix: incorrect Fallout 3 game_info

### DIFF
--- a/configs/game_info.yml
+++ b/configs/game_info.yml
@@ -147,12 +147,18 @@ games:
     display_name: Fallout 3 - Game of the Year Edition
     parent: fallout3
     nexus_slug: fallout3
-    executable: Fallout3Launcher.exe
+    executable:
+      steam: Fallout3Launcher.exe
+      gog: FalloutLauncher.exe
+      epic: Fallout 3 GOTY English/FalloutLauncherEpic.exe
     launcher_ids:
       steam: 22370
       gog: 1454315831
       epic: adeae8bbfc94427db57c7dfecce3f1d4
-    subdirectory: Fallout 3 goty
+    subdirectory:
+      steam: Fallout 3 goty
+      gog: Fallout 3
+      epic: fallout3
 
   fallout4:
     display_name: Fallout 4

--- a/configs/game_info.yml
+++ b/configs/game_info.yml
@@ -90,7 +90,7 @@ games:
     launcher_ids:
       steam: 22300
     subdirectory: Fallout 3
-    executable: Fallout3.exe
+    executable: Fallout3Launcher.exe
     tricks:
       - "d3dcompiler_43"
       - "d3dx9"
@@ -144,8 +144,10 @@ games:
             - "fose_loader.exe"
 
   fallout3_goty:
+    display_name: Fallout 3 - Game of the Year Edition
     parent: fallout3
     nexus_slug: fallout3
+    executable: Fallout3Launcher.exe
     launcher_ids:
       steam: 22370
       gog: 1454315831


### PR DESCRIPTION
Corrects the executable name, as well as expands the Fallout 3 GOTY entry with proper Epic and GOG data from egdata.app and gogdb.org

Untested, currently I do not own Fallout 3 on Epic or GOG

Resolves #941, Resolves #997