### PR TITLE
Stop install when game path is missing

### DIFF
--- a/src/mo2-lint/command/install.py
+++ b/src/mo2-lint/command/install.py
@@ -45,6 +45,13 @@ def install(
             if isinstance(var.game_info.executable, dict)
             else var.game_info.executable
         )
+        game_path = get_library()
+        if game_path is None:
+            logger.critical(
+                "Could not determine the game installation path. Aborting installation before modifying the instance."
+            )
+            raise SystemExit(1)
+
         state.current_instance = InstanceData(
             index=-1,
             game=game,
@@ -52,7 +59,7 @@ def install(
             instance_path=directory,
             launcher=launcher,
             launcher_ids=var.LauncherIDs.from_dict(var.game_info.launcher_ids),
-            game_path=get_library(),
+            game_path=game_path,
             game_executable=executable,
             script_extender=None,
             plugins=list(plugin),

--- a/src/mo2-lint/util/redirector/install.py
+++ b/src/mo2-lint/util/redirector/install.py
@@ -39,6 +39,10 @@ def install():
     """
 
     logger.info("Installing redirector.")
+    if not state.current_instance or not state.current_instance.game_path:
+        logger.critical("Cannot install redirector because the game path is not set.")
+        raise SystemExit(1)
+
     game_install_path = (
         state.current_instance.game_path
         if state.current_instance.game_path.is_dir()


### PR DESCRIPTION
Fixes #1020.

The installer can continue with `state.current_instance.game_path` set to `None` when the game library cannot be resolved. That eventually reaches the redirector step and crashes with `AttributeError: 'NoneType' object has no attribute 'is_dir'`, which hides the real failure.

This change stops the install as soon as the game path lookup fails, before the instance is created and before later install steps run. I also added the same guard inside the redirector installer so update/older-state paths fail with a clear message instead of the same `NoneType` traceback.

Checked locally:

- `python -m compileall src`
- `ruff check src`
- a small local import check for the missing `game_path` redirector guard

I could not run the full `uv` workflow here because this Windows environment does not have `uv` installed and only has Python 3.12, while the project requires Python 3.13.