### PR TITLE
Fix KeyError when selecting a script extender

### DIFF
--- a/src/mo2-lint/step/external_resources.py
+++ b/src/mo2-lint/step/external_resources.py
@@ -138,14 +138,15 @@ def download_scriptextender():
 
     if matches:
         match_count = len(matches)
+        keys = list(matches.keys())
         if match_count < 1 or None:
             return
         elif match_count == 1:
-            choice = matches[0]
+            choice = matches[keys[0]]
         elif match_count > 1:
             choice = lang.prompt_install_scriptextender_choice(matches)
-            index = choice if (0 < choice <= match_count) else None
-            choice = matches[index]
+            index = keys[choice] if 0 <= choice < match_count else None
+            choice = matches[index] if index is not None else None
     else:
         return
     logger.debug(f"Chosen script extender entry: {choice}")


### PR DESCRIPTION
I was getting a `KeyError: None` crash when trying to run the latest 7.0 RC. It seems like there was an off-by-one error in match checking which was not allowing a script-extender choice of 0 to be selected. This PR updates `0 < choice <= match_count` to `0 <= choice < match_count` and adds a more robust index based on actual key since technically `matches` can have empty indices.