### PR TITLE
Add ability to use a custom install path

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -37,6 +37,13 @@ mo2-lint install <game> <directory> [options]
 >
 > - `--launcher <launcher>`, `-L <launcher>` - Force a specific launcher (`steam`, `gog`, or `epic`) instead of auto-detecting.
 >
+> - `--mo2-archive <path/to/archive>` - Install Mod Organizer 2 from a local `.zip`/`.7z` archive instead of downloading the bundled version. Useful for offline installs or holding an instance at a specific MO2 build. Requires `--mo2-checksum`. The instance is automatically pinned (see [`pin`](#pin)) so a later `update` will not overwrite your chosen build.
+>   ```bash
+>   mo2-lint install skyrim /path/to/instance --mo2-archive ~/Downloads/Mod.Organizer-2.5.2.7z --mo2-checksum <sha256>
+>   ```
+>
+> - `--mo2-checksum <sha256>` - The expected SHA-256 checksum of the `--mo2-archive` file. Required when `--mo2-archive` is used; the archive is verified against it before extraction.
+>
 > - `--custom <path/to/file.yml>` - **[Advanced users only, unsupported]** Use a custom game info file. See [Adding Custom Games](./custom-games) for details.
 
 After installation, **launch the game through Steam or Heroic** to confirm the launch option was created. You should see a "Launch Mod Organizer" entry alongside the default launch option.
@@ -94,13 +101,21 @@ mo2-lint unpin <directory>
 Updates the MO2 executable and NXM handler for an existing instance, and refreshes its launch option.
 
 ```bash
-mo2-lint update <directory>
+mo2-lint update <directory> [options]
 ```
 
 > #### Parameters
 > `<directory>` is required and must be the exact path to the instance.
 
-> **Note:** If the instance is pinned, the MO2 version will not be updated. Run `mo2-lint unpin <directory>` first if you want to update it.
+> #### Options
+> - `--mo2-archive <path/to/archive>` - Update Mod Organizer 2 from a local `.zip`/`.7z` archive instead of downloading the bundled version. Requires `--mo2-checksum`. After the update the instance is automatically pinned so a later bundled `update` will not overwrite it.
+>   ```bash
+>   mo2-lint update ~/Games/instance --mo2-archive ~/Downloads/Mod.Organizer-2.5.2.7z --mo2-checksum <sha256>
+>   ```
+>
+> - `--mo2-checksum <sha256>` - The expected SHA-256 checksum of the `--mo2-archive` file. Required when `--mo2-archive` is used; the archive is verified against it before extraction.
+
+> **Note:** If the instance is pinned, the MO2 version will not be updated by a normal `update`. Run `mo2-lint unpin <directory>` first **or** supply `--mo2-archive`, which overrides the pin for that update (and re-pins the instance afterward).
 
 ## The Instance State File
 

--- a/src/mo2-lint/__init__.py
+++ b/src/mo2-lint/__init__.py
@@ -271,6 +271,35 @@ def click_arg_game(required=False):
     )
 
 
+click_opt_mo2_archive = click.option(
+    "--mo2-archive",
+    "mo2_archive",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    default=None,
+    help="Install MO2 from a local .zip/.7z archive instead of downloading.",
+)
+click_opt_mo2_checksum = click.option(
+    "--mo2-checksum",
+    "mo2_checksum",
+    type=str,
+    default=None,
+    help="SHA-256 checksum of the --mo2-archive file (required with it).",
+)
+
+
+def validate_mo2_archive(mo2_archive: Optional[str], mo2_checksum: Optional[str]):
+    if not mo2_archive:
+        return
+    if not mo2_checksum:
+        logger.critical("--mo2-checksum is required when --mo2-archive is provided.")
+        raise SystemExit(1)
+    if Path(mo2_archive).suffix.lower() not in (".zip", ".7z"):
+        logger.critical(
+            f"--mo2-archive must be a .zip or .7z file, but got '{Path(mo2_archive).name}'."
+        )
+        raise SystemExit(1)
+
+
 class CustomCommand(click.Command):  # Move [OPTIONS] to the end in the full help text
     class MoveOptions(click.Command):
         def get_help(self, ctx):
@@ -318,6 +347,8 @@ def cli(ctx):
     multiple=True,
     help="Specify MO2 plugins to download and install.",
 )
+@click_opt_mo2_archive
+@click_opt_mo2_checksum
 @click_arg_game(required=True)
 @click_arg_directory(required=True)
 def install(
@@ -327,12 +358,14 @@ def install(
     launcher: Optional[str],
     script_extender: bool,
     plugin: tuple[str],
+    mo2_archive: Optional[str],
+    mo2_checksum: Optional[str],
     log_level,
     unattended: bool,
 ):
     game, directory = start(game, directory, game_info_path, log_level, unattended)
     logger.debug(
-        f"Running install command with game={game}, directory={directory}, game_info_path={game_info_path}, launcher={launcher}, script_extender={script_extender}, plugin={plugin}"
+        f"Running install command with game={game}, directory={directory}, game_info_path={game_info_path}, launcher={launcher}, script_extender={script_extender}, plugin={plugin}, mo2_archive={mo2_archive}"
     )
     if plugin:
         for p in plugin:
@@ -341,6 +374,7 @@ def install(
                     f"Plugin '{p}' not supported. Available plugins: {list(var.plugin_info.keys())}",
                 )
                 raise SystemExit(1)
+    validate_mo2_archive(mo2_archive, mo2_checksum)
     _install(
         game,
         directory,
@@ -349,6 +383,8 @@ def install(
         script_extender,
         plugin,
         launcher,
+        Path(mo2_archive) if mo2_archive else None,
+        mo2_checksum,
     )
     state.write_state()
 
@@ -422,13 +458,28 @@ def unpin(directory: Path, log_level, unattended: bool):
 @click_help
 @click_log_level
 @click_unattended
+@click_opt_mo2_archive
+@click_opt_mo2_checksum
 @click_arg_directory(required=True)
-def update(directory: Path, log_level, unattended: bool):
+def update(
+    directory: Path,
+    mo2_archive: Optional[str],
+    mo2_checksum: Optional[str],
+    log_level,
+    unattended: bool,
+):
     waste, directory = start(
         directory=directory, log_level=log_level, unattended=unattended
     )
-    logger.debug(f"Running update command with directory={directory}")
-    _update(directory)
+    logger.debug(
+        f"Running update command with directory={directory}, mo2_archive={mo2_archive}"
+    )
+    validate_mo2_archive(mo2_archive, mo2_checksum)
+    _update(
+        directory,
+        Path(mo2_archive) if mo2_archive else None,
+        mo2_checksum,
+    )
 
 
 if __name__ == "__main__":

--- a/src/mo2-lint/command/install.py
+++ b/src/mo2-lint/command/install.py
@@ -22,6 +22,8 @@ def install(
     script_extender: bool = False,
     plugin: Optional[tuple[str]] = (),
     launcher: Optional[str] = None,
+    mo2_archive: Optional[Path] = None,
+    mo2_checksum: Optional[str] = None,
 ):
     var.set_parameters(
         {
@@ -31,6 +33,8 @@ def install(
             "log_level": log_level,
             "script_extender": script_extender,
             "plugins": list(plugin),
+            "mo2_archive": mo2_archive,
+            "mo2_checksum": mo2_checksum,
         }
     )
     logger.debug(f"Starting installation with parameters: {var.input_params}")
@@ -50,6 +54,7 @@ def install(
             game=game,
             nexus_slug=var.game_info.nexus_slug,
             instance_path=directory,
+            pin=mo2_archive is not None,
             launcher=launcher,
             launcher_ids=var.LauncherIDs.from_dict(var.game_info.launcher_ids),
             game_path=get_library(),

--- a/src/mo2-lint/command/update.py
+++ b/src/mo2-lint/command/update.py
@@ -2,6 +2,7 @@
 
 from loguru import logger
 from pathlib import Path
+from typing import Optional
 from step.external_resources import download_mod_organizer
 from util import state_file as state, variables as var
 from step.launch_opt import add_launch_opt, remove_launch_opt
@@ -10,7 +11,11 @@ from util.nexus.install_handler import install as install_handler
 from util.wine import protontricks, winetricks
 
 
-def update(directory: Path):
+def update(
+    directory: Path,
+    mo2_archive: Optional[Path] = None,
+    mo2_checksum: Optional[str] = None,
+):
     """
     Updates the MO2 instance located at the given directory and refreshes the launch option.
     """
@@ -23,6 +28,8 @@ def update(directory: Path):
             "log_level": None,
             "script_extender": None,
             "plugins": [],
+            "mo2_archive": mo2_archive,
+            "mo2_checksum": mo2_checksum,
         }
     )
 
@@ -46,13 +53,23 @@ def update(directory: Path):
     var.load_game_info(state.current_instance.game)
 
     if state.current_instance.pin is True:
-        logger.warning(
-            "Instance is pinned. Please unpin the instance if you want to update it."
-        )
-        return
+        if mo2_archive:
+            logger.info(
+                "Instance is pinned, but a local archive was supplied; overriding the pin for this update."
+            )
+        else:
+            logger.warning(
+                "Instance is pinned. Please unpin the instance if you want to update it."
+            )
+            return
 
     logger.debug(f"Updating MO2 executable in directory: {directory}")
     download_mod_organizer()
+
+    if mo2_archive:
+        logger.info("Pinning instance to the supplied local archive build.")
+        state.current_instance.pin = True
+        state.write_state(add_current=True)
 
     logger.info("Updating protontricks")
     if state.current_instance.launcher == "steam":

--- a/src/mo2-lint/step/external_resources.py
+++ b/src/mo2-lint/step/external_resources.py
@@ -26,24 +26,37 @@ def download_mod_organizer():
     Runs the download and installation process for Mod Organizer 2.
     """
 
-    logger.info("Starting download process for Mod Organizer 2")
     url = var.resource_info.mod_organizer.download_url
     checksum = var.resource_info.mod_organizer.checksum
     path_internal = var.resource_info.mod_organizer.path_internal
     checksum_internal = var.resource_info.mod_organizer.checksum_internal
-    logger.trace(
-        f"Download info: url={url}, checksum={checksum}, path_internal={path_internal}, checksum_internal={checksum_internal}"
-    )
+    local_archive = var.input_params.mo2_archive
+    destination = var.input_params.directory
 
-    downloaded = dl(url, download_dir, checksum=checksum)
-    logger.debug(f"Downloaded Mod Organizer 2 to {downloaded}")
+    if local_archive:
+        local_archive = Path(local_archive)
+        logger.info(f"Installing Mod Organizer 2 from local archive: {local_archive}")
+        if not compare_checksum(local_archive, var.input_params.mo2_checksum):
+            logger.critical(
+                f"Checksum mismatch for {local_archive}. Expected {var.input_params.mo2_checksum}."
+            )
+            raise SystemExit(1)
+        downloaded = local_archive
+        destination.mkdir(parents=True, exist_ok=True)
+    else:
+        logger.info("Starting download process for Mod Organizer 2")
+        logger.trace(
+            f"Download info: url={url}, checksum={checksum}, path_internal={path_internal}, checksum_internal={checksum_internal}"
+        )
+        downloaded = dl(url, download_dir, checksum=checksum)
+        logger.debug(f"Downloaded Mod Organizer 2 to {downloaded}")
+
     extracted = extract(downloaded, extract_dir / downloaded.stem)
     if extracted and extracted.exists():
         logger.debug(f"Extracted Mod Organizer 2 to {extracted}")
-        destination = var.input_params.directory
         mo2_exec = destination / path_internal
         if (  # if ModOrganizer.exe exists in destination check if it's the same file
-            destination.exists() and mo2_exec.exists()
+            not local_archive and destination.exists() and mo2_exec.exists()
         ):
             if not compare_checksum(mo2_exec, checksum_internal):
                 if not lang.prompt_install_mo2_checksum_fail(str(mo2_exec)):

--- a/src/mo2-lint/util/variables.py
+++ b/src/mo2-lint/util/variables.py
@@ -40,6 +40,8 @@ class Input:
     log_level: Optional[str] = "INFO"
     script_extender: Optional[bool] = None
     plugins: Optional[Tuple[str, ...]] = field(default_factory=tuple)
+    mo2_archive: Optional[Path] = None
+    mo2_checksum: Optional[str] = None
 
     def __post_init__(self):
         if not self.game:


### PR DESCRIPTION
This PR adds the ability to define a path to an MO2 archive to use as opposed to automatically downloading one. I've been testing it the past month or so and seems to work as I'd expect.

The impetus for this is there has been a beta version of MO2 for about a year with various fixes for Oblivion Remastered and Starfield. These builds are only available via links on Discord at the moment.

The way that it works is when installing you supply `--mo2-archive` AND `--mo2-checksum` which will skip the downloading process and instead install directly from the zip defined by `mo2-archive`. It will also still check the checksum.