### PR TITLE
fix: support Proton game drive paths

### DIFF
--- a/src/redirector/__init__.py
+++ b/src/redirector/__init__.py
@@ -43,6 +43,40 @@ def wine_to_posix(wine_path: str | Path) -> Path:
     return Path(path_str)  # For C:\ or other Windows drives, try to resolve as-is
 
 
+def wine_io_path(wine_path: str | Path) -> Path:
+    path_str = str(wine_path).replace("\\", "/")
+    if os.name == "nt" and len(path_str) > 1 and path_str[1] == ":":
+        return Path(path_str)
+    return wine_to_posix(path_str)
+
+
+def path_parts(path: str | Path) -> list[str]:
+    path_str = str(path).replace("\\", "/")
+    if len(path_str) > 1 and path_str[1] == ":":
+        path_str = path_str[2:]
+    return [part for part in path_str.split("/") if part]
+
+
+def game_dir_matches(game_dir: Path, game_path: Path) -> bool:
+    game_dir_parts = path_parts(game_dir)
+    game_path_parts = path_parts(game_path)
+
+    if game_dir_parts[: len(game_path_parts)] == game_path_parts:
+        return True
+
+    game_dir_str = str(game_dir).replace("\\", "/")
+    if not (len(game_dir_str) > 1 and game_dir_str[1] == ":"):
+        return False
+    if game_dir_str.upper().startswith("Z:"):
+        return False
+
+    max_overlap = min(len(game_dir_parts), len(game_path_parts))
+    for size in range(max_overlap, 1, -1):
+        if game_path_parts[-size:] == game_dir_parts[:size]:
+            return True
+    return False
+
+
 def posix_to_wine(posix_path: str | Path) -> str:
     """
     Convert a POSIX path to Wine (Z:\\) path.
@@ -63,6 +97,9 @@ def posix_to_wine(posix_path: str | Path) -> str:
     if len(path_str) > 1 and path_str[1] == ":":
         return path_str.replace("/", "\\")
 
+    if path_str.startswith("/"):
+        return "Z:\\" + path_str.lstrip("/").replace("/", "\\")
+
     # Convert POSIX to Wine Z:\ path
     path = Path(posix_path).resolve()
     return "Z:\\" + str(path).lstrip("/").replace("/", "\\")
@@ -82,8 +119,8 @@ def write_error_log(error_log: Path, message: str, exc: Exception) -> None:
         Exception object for traceback
     """
     try:
-        wine_to_posix(error_log.parent).mkdir(parents=True, exist_ok=True)
-        with open(wine_to_posix(error_log), "a") as f:
+        wine_io_path(error_log.parent).mkdir(parents=True, exist_ok=True)
+        with open(wine_io_path(error_log), "a") as f:
             f.write(f"{message}: {exc}\n")
             f.write(traceback.format_exc())
     except Exception:
@@ -150,39 +187,42 @@ def get_instance_info(game_dir: Path) -> tuple[Path | None, str | None]:
         Tuple of (mo2_exe_path as Wine path, game_executable_path as POSIX str),
         or (None, None) if an error occurred
     """
-    # Try to read state file with Wine path
-    state_file_posix = wine_to_posix(STATE_FILE)
-    if not state_file_posix.is_file():
-        logger.error(f"State file not found: {state_file_posix}")
+    # Read state file using an explicit Wine path. Converting Z:/home/... to
+    # /home/... inside Wine can accidentally resolve against Proton's game drive.
+    state_file_path = wine_io_path(STATE_FILE)
+    if not state_file_path.is_file():
+        logger.error(f"State file not found: {STATE_FILE} (host: {state_file_path})")
         return None, None
 
     try:
-        with open(state_file_posix, encoding="utf-8") as f:
+        with open(state_file_path, encoding="utf-8") as f:
             state = json.load(f)
     except Exception as e:
         logger.error(f"Failed to read state file: {e}")
         return None, None
 
     # Convert Wine path to POSIX for comparison
-    game_dir_posix = wine_to_posix(game_dir).resolve()
+    game_dir_posix = wine_to_posix(game_dir)
     logger.trace(f"Game dir (Wine): {game_dir}")
     logger.trace(f"Game dir (POSIX): {game_dir_posix}")
 
     for instance in state.get("instances", []):
         try:
             # State file stores POSIX paths
-            game_path = Path(instance.get("game_path", "")).resolve()
-            instance_path = Path(instance["instance_path"]).resolve()
+            game_path = Path(instance.get("game_path", ""))
+            instance_path = Path(instance["instance_path"])
 
             logger.trace(f"Checking instance game_path: {game_path}")
 
             # Check if game_dir is at or under game_path
-            if game_dir_posix == game_path or game_path in game_dir_posix.parents:
+            if game_dir_matches(game_dir_posix, game_path) or game_dir_matches(
+                game_dir, game_path
+            ):
                 game_exe = instance.get("game_executable", "")
 
                 # Build full POSIX path to game executable
                 if game_exe:
-                    game_exe = str((game_path / game_exe).resolve())
+                    game_exe = str(game_path / game_exe)
 
                 # Return both as Wine Z:\ paths for Wine compatibility
                 mo2_exe_wine = posix_to_wine(instance_path / "ModOrganizer.exe")
@@ -315,11 +355,9 @@ def main(argv: list[str]) -> int:
             return 1
 
         # mo2_exe is already a Wine path string, check by trying to convert to POSIX
-        mo2_exe_posix = wine_to_posix(mo2_exe)
-        if not mo2_exe_posix.is_file():
-            logger.error(
-                f"MO2 executable not found: {mo2_exe} (POSIX: {mo2_exe_posix})"
-            )
+        mo2_exe_path = wine_io_path(mo2_exe)
+        if not mo2_exe_path.is_file():
+            logger.error(f"MO2 executable not found: {mo2_exe} (host: {mo2_exe_path})")
             return 1
 
         # Update ModOrganizer.ini with launcher arguments if present
@@ -332,8 +370,8 @@ def main(argv: list[str]) -> int:
                     from mo2_ini import update_mo2_ini  # noqa: PLC0415
 
                 # mo2_exe is Wine format, convert to POSIX for INI update
-                mo2_dir_posix = wine_to_posix(mo2_exe).parent
-                update_mo2_ini(mo2_dir_posix, game_executable, launcher_args)
+                mo2_dir_path = wine_io_path(mo2_exe).parent
+                update_mo2_ini(mo2_dir_path, game_executable, launcher_args)
             except Exception as e:
                 logger.warning(f"Failed to update INI: {e}")
 

--- a/src/redirector/__init__.py
+++ b/src/redirector/__init__.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
-from loguru import logger
-from shared.logger import add_loggers, remove_loggers
-import os
-import sys
 import json
-import yaml
+import os
 import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+from shared.logger import add_loggers, remove_loggers
 
 # Running inside Wine/Proton: Z:\ is Linux root, C:\ is prefix
 STATE_FILE = (
@@ -62,8 +65,7 @@ def posix_to_wine(posix_path: str | Path) -> str:
 
     # Convert POSIX to Wine Z:\ path
     path = Path(posix_path).resolve()
-    wine_path = "Z:\\" + str(path).lstrip("/").replace("/", "\\")
-    return wine_path
+    return "Z:\\" + str(path).lstrip("/").replace("/", "\\")
 
 
 def write_error_log(error_log: Path, message: str, exc: Exception) -> None:
@@ -82,8 +84,6 @@ def write_error_log(error_log: Path, message: str, exc: Exception) -> None:
     try:
         wine_to_posix(error_log.parent).mkdir(parents=True, exist_ok=True)
         with open(wine_to_posix(error_log), "a") as f:
-            import traceback
-
             f.write(f"{message}: {exc}\n")
             f.write(traceback.format_exc())
     except Exception:
@@ -147,7 +147,8 @@ def get_instance_info(game_dir: Path) -> tuple[Path | None, str | None]:
     Returns:
     --------
     tuple[Path | None, str | None]
-        Tuple of (mo2_exe_path as Wine path, game_executable_path as POSIX str), or (None, None) if an error occurred
+        Tuple of (mo2_exe_path as Wine path, game_executable_path as POSIX str),
+        or (None, None) if an error occurred
     """
     # Try to read state file with Wine path
     state_file_posix = wine_to_posix(STATE_FILE)
@@ -253,7 +254,7 @@ def execute_mo2(exe: Path, args: list[str]) -> int:
     logger.debug(f"Executing: {exe_str} {args}")
 
     try:
-        result = subprocess.run([exe_str] + args)
+        result = subprocess.run([exe_str, *args], check=False)
         return result.returncode
     except Exception as e:
         logger.error(f"Failed to execute {exe_str}: {e}")
@@ -278,7 +279,7 @@ def main(argv: list[str]) -> int:
 
     console_sink = None
     try:
-        console_sink = open(os.devnull, "w")
+        console_sink = open(os.devnull, "w")  # noqa: SIM115
         add_loggers(
             script="redirector",
             process="redirector",
@@ -326,9 +327,9 @@ def main(argv: list[str]) -> int:
             logger.info(f"Updating INI with {len(launcher_args)} launcher arguments")
             try:
                 try:
-                    from .mo2_ini import update_mo2_ini
+                    from .mo2_ini import update_mo2_ini  # noqa: PLC0415
                 except ImportError:
-                    from mo2_ini import update_mo2_ini
+                    from mo2_ini import update_mo2_ini  # noqa: PLC0415
 
                 # mo2_exe is Wine format, convert to POSIX for INI update
                 mo2_dir_posix = wine_to_posix(mo2_exe).parent

--- a/tests/test_redirector_paths.py
+++ b/tests/test_redirector_paths.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+from unittest import TestCase, mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from redirector import game_dir_matches, get_instance_info, posix_to_wine, wine_io_path
+
+
+class RedirectorPathTests(TestCase):
+    def test_z_drive_state_path_uses_explicit_wine_path_under_wine(self):
+        with mock.patch("redirector.os.name", "nt"):
+            assert (
+                str(wine_io_path("Z:/home/deck/.config/mo2-lint/state.json")).replace(
+                    "\\", "/"
+                )
+                == "Z:/home/deck/.config/mo2-lint/state.json"
+            )
+
+    def test_z_drive_path_maps_to_posix_path_outside_wine(self):
+        with mock.patch("redirector.os.name", "posix"):
+            assert (
+                str(wine_io_path("Z:/home/deck/.config/mo2-lint/state.json"))
+                == "/home/deck/.config/mo2-lint/state.json"
+            )
+
+    def test_posix_to_wine_keeps_home_paths_on_z_drive(self):
+        assert (
+            posix_to_wine("/home/deck/Documents/mo2/ModOrganizer.exe")
+            == r"Z:\home\deck\Documents\mo2\ModOrganizer.exe"
+        )
+
+    def test_game_dir_matches_normal_z_drive_launch(self):
+        assert game_dir_matches(
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+        )
+
+    def test_game_dir_matches_wine_z_drive_launch(self):
+        assert game_dir_matches(
+            Path("Z:/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+        )
+
+    def test_game_dir_matches_proton_game_drive_launch(self):
+        assert game_dir_matches(
+            Path("S:/common/Cyberpunk 2077"),
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+        )
+
+    def test_game_dir_matches_subdirectory_under_proton_game_drive(self):
+        assert game_dir_matches(
+            Path("S:/common/Cyberpunk 2077/bin/x64"),
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+        )
+
+    def test_game_dir_rejects_unrelated_game_drive_path(self):
+        assert not game_dir_matches(
+            Path("S:/common/Other Game"),
+            Path("/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"),
+        )
+
+    def test_instance_paths_from_state_stay_on_z_drive_with_game_drive(self):
+        state = {
+            "instances": [
+                {
+                    "game_path": (
+                        "/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"
+                    ),
+                    "instance_path": "/home/deck/Documents/mo2",
+                    "game_executable": "bin/x64/Cyberpunk2077.exe",
+                }
+            ]
+        }
+
+        state_path = mock.Mock()
+        state_path.is_file.return_value = True
+        state_path.__fspath__ = lambda _: "/mock/state.json"
+
+        with (
+            mock.patch("redirector.wine_io_path", return_value=state_path),
+            mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(state))),
+        ):
+            mo2_exe, game_exe = get_instance_info(Path("S:/common/Cyberpunk 2077"))
+
+        assert str(mo2_exe) == r"Z:\home\deck\Documents\mo2\ModOrganizer.exe"
+        assert (
+            game_exe == "/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077/"
+            "bin/x64/Cyberpunk2077.exe"
+        )
+
+    def test_instance_paths_from_state_stay_on_z_drive_with_z_drive(self):
+        state = {
+            "instances": [
+                {
+                    "game_path": (
+                        "/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077"
+                    ),
+                    "instance_path": "/home/deck/Documents/mo2",
+                    "game_executable": "bin/x64/Cyberpunk2077.exe",
+                }
+            ]
+        }
+
+        state_path = mock.Mock()
+        state_path.is_file.return_value = True
+        state_path.__fspath__ = lambda _: "/mock/state.json"
+
+        with (
+            mock.patch("redirector.wine_io_path", return_value=state_path),
+            mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(state))),
+        ):
+            mo2_exe, game_exe = get_instance_info(
+                Path("Z:/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077")
+            )
+
+        assert str(mo2_exe) == r"Z:\home\deck\Documents\mo2\ModOrganizer.exe"
+        assert (
+            game_exe == "/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077/"
+            "bin/x64/Cyberpunk2077.exe"
+        )


### PR DESCRIPTION
[Proton recently added a feature to create an `S:` drive] in the Wine prefix, distinct from the typical `Z:` drive, that points at the Steam library containing the app being launched.

Valve was enabling this for select games by adding `gamedrive` to `proton_compat_config`, as seen in [SteamDB for Cyberpunk 2077]. The option is now enabled by default as of [this commit]. This caused #993 because the redirector could resolve `Z:/home/...` paths against `S:` instead of Linux root, so it looked in the wrong place and could not find `state.json`.

To fix the issue, keep explicit Wine drive paths when reading or checking redirector-managed files. Normalize Wine and POSIX path components before comparing game directories, so both `Z:/home/...` and `S:/common/<game>` launch paths match the stored Steam library `path.

Fixes #993

I've tested this on a prefix with `PROTON_SET_GAME_DRIVE=0`, then `PROTON_SET_GAME_DRIVE=1`, and `PROTON_SET_GAME_DRIVE=0` again and it seems to work.

[Proton recently added a feature to create an `S:` drive]: https://github.com/ValveSoftware/Proton/commit/4c0f01e2d
[SteamDB for Cyberpunk 2077]: https://steamdb.info/app/1091500/info/
[this commit]: https://github.com/ValveSoftware/Proton/commit/7b70313e3
