### PR TITLE
fix: cyberpunk 2077 not launching

### DIFF
--- a/configs/game_info.yml
+++ b/configs/game_info.yml
@@ -27,6 +27,13 @@ games:
       - "xaudio2_7=native"
       - "d3dcompiler_47"
       - "vcrun2022"
+    workarounds:
+      - instance_files:
+        - download_url: "https://github.com/ModOrganizer2/modorganizer/releases/download/v2.5.0/Mod.Organizer-2.5.0.7z"
+          checksum: "9f20a7f2807f5b5a0f801e749d1f4f9160d32b684fe4c27a2d70b0f29fa0fc94"
+          path_internal: "uibase.dll"
+          checksum_internal: "b52ff121ab23e0e6a4cf4d12722b3447579047fdcd42582bbfcda94be7bc7c07"
+          destination: "uibase.dll"
 
   dragonage:
     display_name: 'Dragon Age: Origins - Ultimate Edition'

--- a/src/mo2-lint/step/workarounds.py
+++ b/src/mo2-lint/step/workarounds.py
@@ -3,8 +3,49 @@
 from loguru import logger
 from pathlib import Path
 from shutil import copyfile
+from util.checksum import compare_checksum
 from util import variables as var, state_file as state
 from util.internal_file import internal_file
+
+
+def apply_instance_files(files: list[dict]):
+    from .external_resources import download_dir, extract, extract_dir
+    from util.download import download
+
+    instance_path = Path(state.current_instance.instance_path)
+    workaround_dir = download_dir / "workarounds"
+
+    for file_info in files:
+        url = file_info.get("download_url")
+        source = file_info.get("path_internal")
+        destination = file_info.get("destination") or source
+
+        if not url or not source:
+            logger.warning(f"Skipping invalid instance file workaround: {file_info}")
+            continue
+
+        logger.debug(f"Downloading instance file workaround source: {url}")
+        downloaded = download(url, workaround_dir, checksum=file_info.get("checksum"))
+        extracted = extract(downloaded, extract_dir / "workarounds" / downloaded.stem)
+        src = extracted / source
+
+        checksum_internal = file_info.get("checksum_internal")
+        if checksum_internal and not compare_checksum(src, checksum_internal):
+            logger.critical(
+                f"Checksum mismatch for workaround file {src}. Expected {checksum_internal}."
+            )
+            raise SystemExit(1)
+
+        dest = instance_path / destination
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            logger.debug(
+                f"Removing existing instance file before workaround copy: {dest}"
+            )
+            dest.unlink()
+
+        copyfile(src, dest)
+        logger.trace(f"Copied instance workaround file from {src} to {dest}")
 
 
 def apply_workarounds():
@@ -35,3 +76,6 @@ def apply_workarounds():
 
                     logger.debug("Downloading Java for workaround: needs_java")
                     download_java()
+                if t == "instance_files":
+                    logger.debug(f"Copying instance files for workaround: {w}")
+                    apply_instance_files(w)


### PR DESCRIPTION
For some reason, specifically with Cyberpunk 2077, the uibase.dll file that comes with 2.5.2 makes it so MO2 refuses to launch.. Why this file, why cyberpunk? Who the hell knows.

The workaround? Download 2.5.0 and replace with the uibase.dll from *that*, because it works for some reason. Yippee.