### PR TITLE
feat: check for cabextract presence before installing arial

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -13,6 +13,7 @@ parent: Mod Organizer 2 Linux Installer
 - **Proton 10.0** - Earlier versions may work. MO2-LINT currently only supports Proton 10
 - **XDG Mime** - This is used to send Nexus Mods downloads to MO2. It is included in many distros by default.
 - **procps** - This is used for the `pgrep` command, which is used to automatically restart the launcher while adding launch options. It is included in many distros by default, but on Fedora you need to install the `procps-ng` package.
+- **cabextract** - This is used by *protontricks* to extract files for the `arial` trick. The installer will still work without it, but you may experience a visual bug with MO2. Most distros do not include this by default, so you may need to install it manually.
 - [Optional] **Protontricks** - Protontricks is bundled with MO2-LINT, but you can also install it separately if you want. It is used to manage the Proton prefix and install necessary dependencies for MO2.
 - [Optional] **Winetricks** - The script will download winetricks if necessary, but you can also install it separately if you want. It is used to install necessary dependencies for MO2.
 

--- a/src/mo2-lint/step/configure_prefix.py
+++ b/src/mo2-lint/step/configure_prefix.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 
-from loguru import logger
+import shutil
 from pathlib import Path
+
+from loguru import logger
 from step.load_game_info import get_launcher
-from util import lang, variables as var, state_file as state
+from util import lang
+from util import state_file as state
+from util import variables as var
 from util.heroic.find_library import get_data as get_heroic_data
 from util.wine import protontricks, winetricks
 
@@ -15,6 +19,16 @@ default_tricks = [
 ]
 
 yes = ("", "y", "yes")
+
+
+def get_default_tricks() -> list[str]:
+    tricks = list(default_tricks)
+    if shutil.which("cabextract") is None and "arial" in tricks:
+        logger.warning(
+            "cabextract was not found on the host system; skipping the arial winetricks trick."
+        )
+        tricks.remove("arial")
+    return tricks
 
 
 def load_prefix() -> Path:
@@ -77,7 +91,7 @@ def configure():
     """
     Run the necessary winetricks/protontricks for the selected game launcher.
     """
-    tricks = default_tricks + list(var.game_info.tricks)
+    tricks = get_default_tricks() + list(var.game_info.tricks)
     logger.debug(f"Configuring prefix with the following tricks: {tricks}")
     match var.launcher:
         case "steam":


### PR DESCRIPTION
`cabextract` is used by protontricks for extraction when installing the `arial` trick, but is not included by default in most distros. Adding documentation and pre-install check.