### PR TITLE
feat: open folders from MO2 in Linux default

### DIFF
--- a/configs/tweaks.reg
+++ b/configs/tweaks.reg
@@ -1,0 +1,24 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CLASSES_ROOT\.ini]
+@="inifile"
+"Content Type"="text/plain"
+
+[HKEY_CLASSES_ROOT\inifile\shell\open\command]
+@="/bin/sh /home/user/.local/bin/wine2linux xdg-open \"%1\""
+
+[HKEY_CLASSES_ROOT\.txt]
+@="txtfile"
+"Content Type"="text/plain"
+
+[HKEY_CLASSES_ROOT\txtfile\shell\open\command]
+@="/bin/sh /home/user/.local/bin/wine2linux xdg-open \"%1\""
+
+[HKEY_CLASSES_ROOT\folder\shell\open\command]
+@="/bin/sh /home/user/.local/bin/wine2linux xdg-open \"%1\""
+
+[HKEY_CLASSES_ROOT\folder\shell\explore\command]
+@="/bin/sh /home/user/.local/bin/wine2linux xdg-open \"%1\""
+
+[HKEY_CURRENT_USER\Software\Wine\DllOverrides]
+"explorer.exe"="native,builtin"

--- a/configs/wine2linux
+++ b/configs/wine2linux
@@ -1,10 +1,23 @@
 #!/bin/sh
 
 APP="$1"
-WINPATH="$2"
-
-WINPATH="${WINPATH#\"}"
+WINPATH="${2#\"}"
 WINPATH="${WINPATH%\"}"
 
-UNIXPATH="$(printf '%s' "$WINPATH" | sed -e 's/\\/\//g' -e 's/^[A-Za-z]://')"
-exec "$APP" "$UNIXPATH"
+DRIVE="$(printf '%s' "$WINPATH" | cut -c1 | tr 'A-Z' 'a-z')"
+REST="$(printf '%s' "$WINPATH" | cut -c3- | sed 's/\\/\//g')"
+DOSDEVICE="$WINEPREFIX/dosdevices/${DRIVE}:"
+
+if [ -L "$DOSDEVICE" ]; then
+  UNIXPATH="$(readlink -f "$DOSDEVICE")$REST"
+else
+  UNIXPATH="$REST"
+fi
+
+LAUNCH_CLIENT="${STEAM_RUNTIME_LAUNCH_SCRIPT:-$PRESSURE_VESSEL_RUNTIME_BASE/pressure-vessel/bin/steam-runtime-launch-client}"
+
+if [ -x "$LAUNCH_CLIENT" ]; then
+  exec "$LAUNCH_CLIENT" --alongside-steam -- gio open "$UNIXPATH"
+else
+  exec "$APP" "$UNIXPATH"
+fi

--- a/configs/wine2linux
+++ b/configs/wine2linux
@@ -16,8 +16,15 @@ fi
 
 LAUNCH_CLIENT="${STEAM_RUNTIME_LAUNCH_SCRIPT:-$PRESSURE_VESSEL_RUNTIME_BASE/pressure-vessel/bin/steam-runtime-launch-client}"
 
-if [ -x "$LAUNCH_CLIENT" ]; then
-  exec "$LAUNCH_CLIENT" --alongside-steam -- gio open "$UNIXPATH"
-else
+if [ ! -x "$LAUNCH_CLIENT" ]; then
   exec "$APP" "$UNIXPATH"
 fi
+
+if [ -f "$UNIXPATH" ] && [ ! -s "$UNIXPATH" ]; then
+  DEFAULT_APP="$("$LAUNCH_CLIENT" --alongside-steam -- gio mime text/plain 2>/dev/null | sed -n '1s/.*: //p')"
+  if [ -n "$DEFAULT_APP" ]; then
+    exec "$LAUNCH_CLIENT" --alongside-steam -- gtk-launch "$DEFAULT_APP" "$UNIXPATH"
+  fi
+fi
+
+exec "$LAUNCH_CLIENT" --alongside-steam -- gio open "$UNIXPATH"

--- a/configs/wine2linux
+++ b/configs/wine2linux
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+APP="$1"
+WINPATH="$2"
+
+WINPATH="${WINPATH#\"}"
+WINPATH="${WINPATH%\"}"
+
+UNIXPATH="$(printf '%s' "$WINPATH" | sed -e 's/\\/\//g' -e 's/^[A-Za-z]://')"
+exec "$APP" "$UNIXPATH"

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -133,7 +133,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="${HOME}/.local/bin:${PATH}"
 
 COPY . .
-RUN chown -R docker:docker /tmp/mo2-lint
+RUN chown -R docker:docker /tmp/mo2-lint /home/docker
 
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/validate.sh /validate.sh

--- a/src/mo2-lint/__init__.py
+++ b/src/mo2-lint/__init__.py
@@ -2,7 +2,10 @@
 
 import re
 import ssl
+import tempfile
+from getpass import getuser
 from pathlib import Path
+from shutil import copy2
 
 import certifi
 import click
@@ -18,6 +21,7 @@ from pydantic_core import from_json
 from util import lang
 from util import state_file as state
 from util import variables as var
+from util.internal_file import internal_file
 
 from shared.logger import add_loggers, remove_loggers
 
@@ -68,10 +72,6 @@ def pull_config():
         config_path = Path("~/.config/mo2-lint/", config).expanduser()
         dest = None
         if not config_path.exists():
-            from shutil import copy2
-
-            from util.internal_file import internal_file
-
             try:
                 logger.debug(
                     f"File does not exist in .config: {config_path}, copying from internal cfg"
@@ -127,6 +127,41 @@ def pull_config():
                     out_file.write(response.read())
         except Exception:
             logger.exception(f"Failed to download config file {config}")
+
+    bin_dir = Path("~/.local/bin").expanduser()
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    wine2linux_path = bin_dir / "wine2linux"
+
+    if not wine2linux_path.exists():
+        try:
+            src = internal_file("cfg", "wine2linux")
+            copy2(src, wine2linux_path)
+            wine2linux_path.chmod(wine2linux_path.stat().st_mode | 0o111)
+            logger.debug(f"Installed wine2linux to {wine2linux_path}")
+        except Exception as e:
+            logger.exception(f"Failed to install wine2linux to {wine2linux_path}: {e}")
+            raise SystemExit(1)
+    else:
+        logger.trace(f"wine2linux already exists: {wine2linux_path}")
+
+    tweaks_file = internal_file("cfg", "tweaks.reg")
+    edit_file = Path(tempfile.gettempdir()) / "mo2-lint-tweaks.reg"
+    user = getuser()
+
+    try:
+        copy2(tweaks_file, edit_file)
+        txt = edit_file.read_text()
+        if user == "user":
+            logger.trace(
+                "Executing user is named user; leaving registry tweak paths unchanged"
+            )
+        else:
+            txt = txt.replace("/home/user", f"/home/{user}")
+            edit_file.write_text(txt)
+            logger.debug(f"Rewrote tweaks.reg for user {user}: {tweaks_file}")
+    except Exception as e:
+        logger.exception(f"Failed to prepare tweaks.reg at {tweaks_file}: {e}")
+        raise SystemExit(1)
 
 
 game_list = None

--- a/src/mo2-lint/step/configure_prefix.py
+++ b/src/mo2-lint/step/configure_prefix.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import shutil
+import tempfile
 from pathlib import Path
 
 from loguru import logger
@@ -95,7 +96,13 @@ def configure():
     logger.debug(f"Configuring prefix with the following tricks: {tricks}")
     match var.launcher:
         case "steam":
-            protontricks.apply(var.game_info.launcher_ids.steam, tricks)
+            app_id = var.game_info.launcher_ids.steam
+            protontricks.apply(app_id, tricks)
+            tweaks_path = Path(tempfile.gettempdir()) / "mo2-lint-tweaks.reg"
+            if tweaks_path.exists():
+                protontricks.import_registry(app_id, tweaks_path)
+            else:
+                logger.warning(f"Registry tweak file not found: {tweaks_path}")
         case "gog" | "epic":
             prefix = var.prefix
             winetricks.apply(prefix=prefix, tricks=tricks)

--- a/src/mo2-lint/util/wine/protontricks.py
+++ b/src/mo2-lint/util/wine/protontricks.py
@@ -194,6 +194,23 @@ def apply(id: int, tricks: list[str]):
     run([f"{id}", "-q", "--force"] + tricks)
 
 
+def import_registry(id: int, registry_file: Path):
+    """
+    Imports a registry file into the specified Proton prefix.
+
+    Parameters
+    ----------
+    id : int
+        The Proton prefix ID.
+    registry_file : Path
+        The registry file to import.
+    """
+
+    registry_file = Path(registry_file).expanduser().resolve()
+    logger.debug(f"Importing registry file into prefix ID {id}: {registry_file}")
+    run(["-c", f'wine regedit /C "{registry_file}"', f"{id}"])
+
+
 def check_prefix(id: int) -> bool:
     """
     Checks if a Proton prefix exists for the given ID.


### PR DESCRIPTION
Reroutes calls for Wine's explorer to the user's default file browser on Linux

### Known issues:
- Does not affect the 'Data' file list.
- ~~.ini and .txt files do not open~~ they did, but zero-byte files didn't, those are classified separately. fixed.