### PR TITLE
settings.toml file

### DIFF
--- a/configs/settings.toml
+++ b/configs/settings.toml
@@ -1,10 +1,13 @@
 [installer]
-log_level = ''                       # Example: 'info', 'debug', 'trace'
+log_level = ''                          # Example: 'info', 'debug', 'trace'
 
 [instance]
-launcher = ''                        # Example: 'steam', 'gog', 'epic'
-theme = ''                           # Example: 'paper-dark'
-plugins = []                         # Example: [ "root-builder", "auto-activator", "fomod-plus", "nxm-collection-dl" ]
+launcher = ''                           # Example: 'steam', 'gog', 'epic'
+theme = ''                              # Example: 'paper-dark'
+plugins = []                            # Example: [ "root-builder", "auto-activator", "fomod-plus", "nxm-collection-dl" ]
 
 [instance.folders]
-root_folder = '~/Games/MO2-LINT'
+root_folder = '~/Games/mo2-lint'        # Where the instance folder will be created.
+folder_name = 'mo2-{game}-{launcher}'   # The actual instance folder name. Placeholders: {game}, {launcher}
+
+# i.e. root_folder = '~/Games/mo2-lint' and folder_name = 'mo2-{game}-{launcher}' will create the instance folder at '~/Games/mo2-lint/mo2-{game}-{launcher}'

--- a/configs/settings.toml
+++ b/configs/settings.toml
@@ -1,5 +1,5 @@
 [installer]
-log_level = ''                          # Example: 'info', 'debug', 'trace'
+log_level = 'info'                          # Example: 'info', 'debug', 'trace'
 check_updates = true                    # Set false to skip the startup GitHub version check.
 refresh_configs = true                  # Set false to skip pulling remote config files on startup.
 

--- a/configs/settings.toml
+++ b/configs/settings.toml
@@ -1,0 +1,10 @@
+[installer]
+log_level = ''                       # Example: 'info', 'debug', 'trace'
+
+[instance]
+launcher = ''                        # Example: 'steam', 'gog', 'epic'
+theme = ''                           # Example: 'paper-dark'
+plugins = []                         # Example: [ "root-builder", "auto-activator", "fomod-plus", "nxm-collection-dl" ]
+
+[instance.folders]
+root_folder = '~/Games/MO2-LINT'

--- a/configs/settings.toml
+++ b/configs/settings.toml
@@ -1,5 +1,7 @@
 [installer]
 log_level = ''                          # Example: 'info', 'debug', 'trace'
+check_updates = true                    # Set false to skip the startup GitHub version check.
+refresh_configs = true                  # Set false to skip pulling remote config files on startup.
 
 [instance]
 launcher = ''                           # Example: 'steam', 'gog', 'epic'

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -22,7 +22,7 @@ mo2-lint install <game> <directory> [options]
 > #### Parameters
 >
 > - `<game>` - The game identifier (e.g. `skyrim`, `fallout4`). Run `mo2-lint install --help` for the full list of supported games. **Required**.
-> - `<directory>` - The path where the MO2 instance will be created. **Optional**, defaults to '~/Games/MO2-LINT' if not specified in command. Default can be changed in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `install_directory`. If the directory already exists, it must be empty.
+> - `<directory>` - The path where the MO2 instance will be created. **Optional**. If omitted, MO2-LINT uses the values from `~/.config/mo2-lint/settings.toml` under `[instance.folders]` to build the final path. `root_folder` sets the base directory, and `folder_name` supports `{game}` and `{launcher}` placeholders. If the directory already exists, it must be empty.
 
 > #### Options
 > - `--plugin <plugin>`, `-p <plugin>` - Install a plugin into the new MO2 instance. Can be specified multiple times:
@@ -116,9 +116,32 @@ mo2-lint update <directory> [options]
 >
 > - `--mo2-checksum <sha256>` - The expected SHA-256 checksum of the `--mo2-archive` file. Required when `--mo2-archive` is used; the archive is verified against it before extraction.
 >
-> - `--theme <name>`, `-t <name>` - Apply a theme to the instance during the update. More information on themes can be found in the [Themes](./themes) section of the documentation. A default can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `launcher`.
+> - `--theme <name>`, `-t <name>` - Apply a theme to the instance during the update. More information on themes can be found in the [Themes](./themes) section of the documentation. A default can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[instance]` as `theme`.
 
 > **Note:** If the instance is pinned, the MO2 version will not be updated by a normal `update`. Run `mo2-lint unpin <directory>` first **or** supply `--mo2-archive`, which overrides the pin for that update (and re-pins the instance afterward).
+
+## The Settings File
+
+MO2-LINT reads its configuration from `~/.config/mo2-lint/settings.toml`.
+
+> #### `[installer]`
+>
+> - `log_level` - Default log level for commands when `--log-level` is not provided. 'INFO' if unset.
+> - `check_updates` - Set to `false` to skip the startup GitHub version check.
+> - `refresh_configs` - Set to `false` to skip pulling remote config files on startup.
+
+> #### `[instance]`
+>
+> - `launcher` - Default launcher to use when one is not provided with --launcher. Can be left blank to auto-detect based on installed launchers. If the selected game is not available on the selected launcher, MO2-LINT will fall back to auto-detection.
+> - `theme` - Default theme to apply when one is not provided with --theme. Can be left blank for no theme.
+> - `plugins` - Default plugins to install with new instances when not provided with --plugin. Can be left blank for no plugins.
+
+> #### `[instance.folders]`
+>
+> - `root_folder` - Base directory for new instances.
+> - `folder_name` - Instance folder template. Supports `{game}` and `{launcher}` placeholders.
+>
+> For example, a `root_folder` of `~/Games` and a `folder_name` of `mo2-{game}` will install a Fallout 4 instance at `~/Games/mo2-fallout4`.
 
 ## The Instance State File
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -20,22 +20,21 @@ mo2-lint install <game> <directory> [options]
 ```
 
 > #### Parameters
-> `<game>` and `<directory>` are required.
 >
-> - `<game>` - The game identifier (e.g. `skyrim`, `fallout4`). Run `mo2-lint install --help` for the full list of supported games.
-> - `<directory>` - The path where the MO2 instance will be created.
+> - `<game>` - The game identifier (e.g. `skyrim`, `fallout4`). Run `mo2-lint install --help` for the full list of supported games. **Required**.
+> - `<directory>` - The path where the MO2 instance will be created. **Optional**, defaults to '~/Games/MO2-LINT' if not specified in command. Default can be changed in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `install_directory`. If the directory already exists, it must be empty.
 
 > #### Options
 > - `--plugin <plugin>`, `-p <plugin>` - Install a plugin into the new MO2 instance. Can be specified multiple times:
 >   ```bash
 >   mo2-lint install skyrim /path/to/instance -p root-builder -p nxm-collection-dl
 >   ```
->   Run `mo2-lint install --help` for the list of available plugins.
+>   Run `mo2-lint install --help` for the list of available plugins. A default list can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `plugins`.
 >
 > - `--script-extender`, `-s` - Install the script extender for the game (e.g. SKSE for Skyrim, F4SE for Fallout 4), if one is available. If multiple versions exist, you will be prompted to choose. Ignored if the game has no script extender.
 >   - If you need different script extender versions across instances, omit this flag and configure the script extender via the `root-builder` plugin instead.
 >
-> - `--launcher <launcher>`, `-L <launcher>` - Force a specific launcher (`steam`, `gog`, or `epic`) instead of auto-detecting.
+> - `--launcher <launcher>`, `-L <launcher>` - Force a specific launcher (`steam`, `gog`, or `epic`) instead of auto-detecting. A default can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `launcher`.
 >
 > - `--mo2-archive <path/to/archive>` - Install Mod Organizer 2 from a local `.zip`/`.7z` archive instead of downloading the bundled version. Useful for offline installs or holding an instance at a specific MO2 build. Requires `--mo2-checksum`. The instance is automatically pinned (see [`pin`](#pin)) so a later `update` will not overwrite your chosen build.
 >   ```bash
@@ -44,7 +43,7 @@ mo2-lint install <game> <directory> [options]
 >
 > - `--mo2-checksum <sha256>` - The expected SHA-256 checksum of the `--mo2-archive` file. Required when `--mo2-archive` is used; the archive is verified against it before extraction.
 >
-> - `--theme <name>`, `-t <name>` - Apply a theme to the new instance. More information on themes can be found in the [Themes](./themes) section of the documentation.
+> - `--theme <name>`, `-t <name>` - Apply a theme to the new instance. A default can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `themes`. More information on themes can be found in the [Themes](./themes) section of the documentation.
 >
 > - `--custom <path/to/file.yml>` - **[Advanced users only, unsupported]** Use a custom game info file. See [Adding Custom Games](./custom-games) for details.
 
@@ -117,7 +116,7 @@ mo2-lint update <directory> [options]
 >
 > - `--mo2-checksum <sha256>` - The expected SHA-256 checksum of the `--mo2-archive` file. Required when `--mo2-archive` is used; the archive is verified against it before extraction.
 >
-> - `--theme <name>`, `-t <name>` - Apply a theme to the instance during the update. More information on themes can be found in the [Themes](./themes) section of the documentation.
+> - `--theme <name>`, `-t <name>` - Apply a theme to the instance during the update. More information on themes can be found in the [Themes](./themes) section of the documentation. A default can be set in the settings file at `~/.config/mo2-lint/settings.toml` under `[installer]` as `launcher`.
 
 > **Note:** If the instance is pinned, the MO2 version will not be updated by a normal `update`. Run `mo2-lint unpin <directory>` first **or** supply `--mo2-archive`, which overrides the pin for that update (and re-pins the instance afterward).
 

--- a/src/mo2-lint/__init__.py
+++ b/src/mo2-lint/__init__.py
@@ -196,9 +196,11 @@ def pre_init():
     """
     remove_loggers()
     add_loggers(log_level="TRACE", script="mo2-lint", process="pre-check")
-    check_update()
-    pull_config()  # Temporarily disable for development
     var.load_settings()
+    if var.settings.check_updates:
+        check_update()
+    if var.settings.refresh_configs:
+        pull_config()  # Temporarily disable for development
     var.load_games_info()
     var.load_resource_info()
     var.load_plugin_info()

--- a/src/mo2-lint/__init__.py
+++ b/src/mo2-lint/__init__.py
@@ -62,6 +62,27 @@ def pull_config():
     Before that, copies default configuration files from internal storage if not already present.
     """
     logger.info("Pulling latest configuration files from GitHub.")
+    settings_path = Path("~/.config/mo2-lint/settings.toml").expanduser()
+    if not settings_path.exists():
+        try:
+            logger.debug(
+                f"Settings file does not exist in .config: {settings_path}, copying from internal cfg"
+            )
+            src = internal_file("cfg", "settings.toml")
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            copy2(src, settings_path)
+            logger.trace(f"Copied src={src} to dest={settings_path}")
+        except Exception as e:
+            logger.exception(
+                f"Failed to copy internal settings.toml to .config folder: {e}"
+            )
+            logger.critical(
+                "Failed to set up settings.toml. Please ensure the application has permission to write to ~/.config/mo2-lint/ and try again."
+            )
+            raise SystemExit(1)
+    else:
+        logger.trace(f"Settings file already exists: {settings_path}")
+
     for config in (
         "game_info.yml",
         "resource_info.yml",
@@ -177,6 +198,7 @@ def pre_init():
     add_loggers(log_level="TRACE", script="mo2-lint", process="pre-check")
     check_update()
     pull_config()  # Temporarily disable for development
+    var.load_settings()
     var.load_games_info()
     var.load_resource_info()
     var.load_plugin_info()
@@ -285,7 +307,9 @@ click_log_level = click.option(
     "-l",
     "log_level",
     type=click.Choice(["DEBUG", "INFO", "TRACE"], case_sensitive=False),
-    default="INFO",
+    default=var.settings.log_level
+    if var.settings and var.settings.log_level
+    else "INFO",
     show_default=True,
     help="Set the logging level.",
 )
@@ -305,7 +329,7 @@ click_opt_theme = click.option(
     "--theme",
     "-t",
     type=click.Choice(["auto", *var.theme_info.keys()], case_sensitive=False),
-    default=None,
+    default=var.settings.theme if var.settings and var.settings.theme else None,
     help=f"Apply an included MO2 theme during installation.\nOptions: [auto, {', '.join(var.theme_info.keys())}]",
 )
 click_opt_directory = click.option(
@@ -323,10 +347,11 @@ click_unattended = click.option(
 )
 
 
-def click_arg_directory(required=False):
+def click_arg_directory(required=False, default=None):
     return click.argument(
         "directory",
         required=required,
+        default=default,
         type=click.Path(file_okay=False, dir_okay=True),
         metavar="[DIRECTORY]",
     )
@@ -401,7 +426,7 @@ def cli(ctx):
     "--launcher",
     "-L",
     type=click.Choice(["steam", "gog", "epic"], case_sensitive=False),
-    default=None,
+    default=var.settings.launcher if var.settings and var.settings.launcher else None,
     help="Force a specific launcher instead of auto-detecting.",
 )
 @click.option(
@@ -416,12 +441,20 @@ def cli(ctx):
     "-p",
     type=str,
     multiple=True,
+    default=tuple(var.settings.plugins)
+    if var.settings and var.settings.plugins
+    else (),
     help="Specify MO2 plugins to download and install.",
 )
 @click_opt_mo2_archive
 @click_opt_mo2_checksum
 @click_arg_game(required=True)
-@click_arg_directory(required=True)
+@click_arg_directory(
+    required=False,
+    default=var.settings.root_folder
+    if var.settings and var.settings.root_folder
+    else None,
+)
 def install(
     game: str,
     directory: Path,

--- a/src/mo2-lint/__init__.py
+++ b/src/mo2-lint/__init__.py
@@ -449,15 +449,10 @@ def cli(ctx):
 @click_opt_mo2_archive
 @click_opt_mo2_checksum
 @click_arg_game(required=True)
-@click_arg_directory(
-    required=False,
-    default=var.settings.root_folder
-    if var.settings and var.settings.root_folder
-    else None,
-)
+@click_arg_directory(required=False)
 def install(
     game: str,
-    directory: Path,
+    directory: Path | None,
     game_info_path: Path | None,
     launcher: str | None,
     script_extender: bool,

--- a/src/mo2-lint/command/install.py
+++ b/src/mo2-lint/command/install.py
@@ -15,9 +15,48 @@ from util.redirector.install import install as install_redirector
 from util.state_file import InstanceData, set_index
 
 
+def get_install_dir(
+    game: str,
+    directory: Path | None,
+    launcher: str | None,
+) -> Path | None:
+    if directory:
+        return Path(directory).expanduser().resolve()
+
+    if not var.settings or not var.settings.root_folder:
+        return None
+
+    root_folder = var.settings.root_folder.expanduser().resolve()
+    folder_name = var.settings.folder_name
+    if not folder_name:
+        return root_folder
+
+    resolved_launcher = launcher or var.settings.launcher
+    if "{launcher}" in folder_name and not resolved_launcher:
+        resolved_launcher = get_launcher()
+    if "{launcher}" in folder_name and not resolved_launcher:
+        logger.critical(
+            "folder_name uses the {launcher} placeholder, but no launcher could be determined."
+        )
+        raise SystemExit(1)
+
+    try:
+        rendered_folder_name = folder_name.format(
+            game=game,
+            launcher=resolved_launcher or "",
+        )
+    except KeyError as error:
+        logger.critical(f"Unknown folder_name placeholder: {error.args[0]}")
+        raise SystemExit(1)
+    if not rendered_folder_name:
+        return root_folder
+
+    return root_folder / rendered_folder_name
+
+
 def install(
     game: str,
-    directory: Path,
+    directory: Path | None,
     game_info_path: Path | None = None,
     log_level: str = "INFO",
     script_extender: bool = False,
@@ -27,6 +66,7 @@ def install(
     mo2_archive: Path | None = None,
     mo2_checksum: str | None = None,
 ):
+    directory = get_install_dir(game, directory, launcher)
     var.set_parameters(
         {
             "game": game,

--- a/src/mo2-lint/util/variables.py
+++ b/src/mo2-lint/util/variables.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
@@ -58,16 +59,34 @@ class Input:
             raise SystemExit(1)
         if not self.directory:
             logger.critical(
-                "variables.Input: 'directory' parameter is required but was not provided."
+                "variables.Input: 'directory' is required. Set install_directory in settings.toml or pass a directory to the install command."
             )
             logger.critical(
-                "This should not happen. Please report this to the developer."
+                "This is expected when neither source provides a directory. Please set one of them and try again."
             )
             raise SystemExit(1)
 
 
 input_params: Input = None
 unattended: bool = False
+
+
+@dataclass
+class GameSettings:
+    script_extender_version: str | None = None
+
+
+@dataclass
+class InstallerSettings:
+    root_folder: Path | None = None
+    launcher: str | None = None
+    theme: str | None = None
+    plugins: tuple[str, ...] = field(default_factory=tuple)
+    log_level: str | None = None
+    games: dict[str, GameSettings] = field(default_factory=dict)
+
+
+settings: InstallerSettings | None = None
 
 
 def set_parameters(args: Input | dict):
@@ -85,6 +104,53 @@ def set_parameters(args: Input | dict):
         input_params = Input(**args)
     elif isinstance(args, Input):
         input_params = args
+
+
+def load_settings(path: Path | None = None):
+    """
+    Loads settings from ~/.config/mo2-lint/settings.toml.
+
+    Parameters
+    -----------
+    path : Path, optional
+        Path to the settings TOML file. If not provided, defaults to ~/.config/mo2-lint/settings.toml.
+    """
+
+    global settings
+    if not path:
+        path = Path("~/.config/mo2-lint/settings.toml").expanduser()
+
+    if not path.exists():
+        logger.warning(f"Settings TOML file not found at {path}. Using empty settings.")
+        settings = InstallerSettings()
+        return
+
+    logger.debug(f"Loading settings from {path}")
+    with open(path, "rb") as file:
+        toml_data = tomllib.load(file)
+    logger.trace(f"Parsed settings TOML: {toml_data}")
+
+    installer = toml_data.get("installer", {}) or {}
+    instance = toml_data.get("instance", {}) or {}
+    folders = instance.get("folders", {}) or {}
+    root_folder = folders.get("root_folder") or installer.get("install_directory")
+    launcher = instance.get("launcher") or installer.get("launcher") or None
+    theme = instance.get("theme") or installer.get("themes") or None
+    plugins = tuple(instance.get("plugins") or installer.get("plugins") or ())
+    games = {
+        key: GameSettings(script_extender_version=value.get("script_extender_version"))
+        for key, value in (toml_data.get("games", {}) or {}).items()
+        if isinstance(value, dict)
+    }
+    settings = InstallerSettings(
+        root_folder=Path(root_folder).expanduser() if root_folder else None,
+        launcher=launcher,
+        theme=theme,
+        plugins=plugins,
+        log_level=installer.get("log_level") or None,
+        games=games,
+    )
+    logger.trace(f"Loaded settings: {settings}")
 
 
 @dataclass

--- a/src/mo2-lint/util/variables.py
+++ b/src/mo2-lint/util/variables.py
@@ -82,6 +82,7 @@ class InstallerSettings:
     launcher: str | None = None
     theme: str | None = None
     plugins: tuple[str, ...] = field(default_factory=tuple)
+    folder_name: str | None = None
     log_level: str | None = None
     games: dict[str, GameSettings] = field(default_factory=dict)
 
@@ -137,6 +138,7 @@ def load_settings(path: Path | None = None):
     launcher = instance.get("launcher") or installer.get("launcher") or None
     theme = instance.get("theme") or installer.get("themes") or None
     plugins = tuple(instance.get("plugins") or installer.get("plugins") or ())
+    folder_name = folders.get("folder_name") or None
     games = {
         key: GameSettings(script_extender_version=value.get("script_extender_version"))
         for key, value in (toml_data.get("games", {}) or {}).items()
@@ -147,6 +149,7 @@ def load_settings(path: Path | None = None):
         launcher=launcher,
         theme=theme,
         plugins=plugins,
+        folder_name=folder_name,
         log_level=installer.get("log_level") or None,
         games=games,
     )

--- a/src/mo2-lint/util/variables.py
+++ b/src/mo2-lint/util/variables.py
@@ -83,6 +83,8 @@ class InstallerSettings:
     theme: str | None = None
     plugins: tuple[str, ...] = field(default_factory=tuple)
     folder_name: str | None = None
+    check_updates: bool = True
+    refresh_configs: bool = True
     log_level: str | None = None
     games: dict[str, GameSettings] = field(default_factory=dict)
 
@@ -150,6 +152,8 @@ def load_settings(path: Path | None = None):
         theme=theme,
         plugins=plugins,
         folder_name=folder_name,
+        check_updates=installer.get("check_updates", True),
+        refresh_configs=installer.get("refresh_configs", True),
         log_level=installer.get("log_level") or None,
         games=games,
     )


### PR DESCRIPTION
Finally, a way to set default settings!

The following options are now available in `~/.config/mo2-lint/settings.toml`:

> #### `[installer]`
>
> - `log_level` - Default log level for commands when `--log-level` is not provided. 'INFO' if unset.
> - `check_updates` - Set to `false` to skip the startup GitHub version check.
> - `refresh_configs` - Set to `false` to skip pulling remote config files on startup.

> #### `[instance]`
>
> - `launcher` - Default launcher to use when one is not provided with --launcher. Can be left blank to auto-detect based on installed launchers. If the selected game is not available on the selected launcher, MO2-LINT will fall back to auto-detection.
> - `theme` - Default theme to apply when one is not provided with --theme. Can be left blank for no theme.
> - `plugins` - Default plugins to install with new instances when not provided with --plugin. Can be left blank for no plugins.

> #### `[instance.folders]`
>
> - `root_folder` - Base directory for new instances.
> - `folder_name` - Instance folder template. Supports `{game}` and `{launcher}` placeholders.
> 
> For example, a `root_folder` of `~/Games` and a `folder_name` of `mo2-{game}` will install a Fallout 4 instance at `~/Games/mo2-fallout4`.