### PR TITLE
fix: resolve internal files correctly when running from source

### DIFF
--- a/src/mo2-lint/util/internal_file.py
+++ b/src/mo2-lint/util/internal_file.py
@@ -5,6 +5,13 @@ from pathlib import Path
 
 from loguru import logger
 
+# Bundle directory names (from the PyInstaller --add-data flags) mapped to their
+# equivalents in the source tree, for when the script is run unfrozen.
+_SOURCE_LAYOUT = {
+    "cfg": "configs",
+    "src": "src/mo2-lint",
+}
+
 
 def internal_file(*parts) -> Path:
     """
@@ -21,6 +28,17 @@ def internal_file(*parts) -> Path:
         The full path to the internal file's temporary location.
     """
 
-    path = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve()))
-    logger.trace(f"Accessing internal file: {path.joinpath(*parts)}")
-    return path.joinpath(*parts)
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass is not None:
+        path = Path(meipass).joinpath(*parts)
+    else:
+        # Unfrozen: resolve against the repository root, remapping the bundle
+        # directory names onto their source-tree equivalents.
+        root = Path(__file__).resolve().parents[3]
+        remapped = list(parts)
+        if remapped:
+            remapped[0] = _SOURCE_LAYOUT.get(remapped[0], remapped[0])
+        path = root.joinpath(*remapped)
+
+    logger.trace(f"Accessing internal file: {path}")
+    return path


### PR DESCRIPTION
## Problem

Running the installer unfrozen (`make run`) crashes immediately:

```
NotADirectoryError: [Errno 20] Not a directory:
'.../src/mo2-lint/util/internal_file.py/cfg/settings.toml'
```

`internal_file()` resolves its base as:

```python
path = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve()))
```

When `sys._MEIPASS` is absent (i.e. not running from a PyInstaller bundle), the fallback is the path of `internal_file.py` *itself* — a file, not a directory. Every call site then joins bundle-relative parts onto it, so the first one to fire, `pull_config()` copying `cfg/settings.toml` into `~/.config/mo2-lint/`, raises `NotADirectoryError`. `pull_config()` catches it and exits with `SystemExit(1)`.

## Fix

Keep the frozen path exactly as-is. For the unfrozen path, resolve against the repository root and remap the bundle directory names declared in the `--add-data` flags onto their source-tree equivalents:

| bundle | source tree |
| --- | --- |
| `cfg` | `configs` |
| `src` | `src/mo2-lint` |

`dist` needs no remapping — it is already `dist/` at the repo root.

## Testing

- `make run ARGS="--help"` now completes and copies `settings.toml`, `game_info.yml`, `resource_info.yml`, `plugin_info.yml`, `theme_info.yml` into `~/.config/mo2-lint/` as intended. Previously it aborted at the first copy.
- Verified the built binary is unaffected (the `_MEIPASS` branch is untouched).
- `ruff check` and `ruff format --check` pass on the changed file.

Environment: Fedora KDE, Python 3.13.15 via `uv`, `7.0.0-rc7`.

Note: `make run install` still needs `dist/mo2-redirector.exe` and `dist/nxm-handler` present, which is a separate concern from this path bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)